### PR TITLE
Add update menu with electron-updater

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -1,7 +1,8 @@
 "use strict"
 
 const electron = require('electron')
-const { app, Tray, nativeImage, globalShortcut, ipcMain } = electron
+const { app, Tray, nativeImage, globalShortcut, ipcMain, Menu, dialog } = electron
+const { autoUpdater } = require('electron-updater')
 const os = require('os')
 const DEBUG = process.env.DEBUG ? true : false
 const MAC = os.type() === 'Darwin' ? true : false
@@ -14,6 +15,34 @@ if (MAC) app.dock.hide()
 app.on('ready', () => {
 
   var screen = electron.screen
+
+  const menuTemplate = [
+    {
+      label: 'Polidium',
+      submenu: [
+        {
+          label: 'Check for Updates...',
+          click () {
+            autoUpdater.checkForUpdates()
+          }
+        },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    }
+  ]
+  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate))
+
+  autoUpdater.on('update-downloaded', () => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Restart', 'Later'],
+      title: 'Update ready',
+      message: 'Update downloaded. Restart now?'
+    }).then(result => {
+      if (result.response === 0) autoUpdater.quitAndInstall()
+    })
+  })
 
   var player = new PlayerWindow()
   var controller = new ControllerWindow()

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "xss": "^0.3.2"
   },
   "dependencies": {
-    "xss": "^0.3.3"
+    "xss": "^0.3.3",
+    "electron-updater": "^2.23.3"
   }
 }


### PR DESCRIPTION
## Summary
- add an update menu that checks GitHub releases
- include electron-updater dependency

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400590d8ec832ab3ce8e8d8e938e87