### PR TITLE
Add initial TypeScript support

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,0 +1,102 @@
+import { app, Tray, nativeImage, globalShortcut, ipcMain, Menu, dialog, screen, BrowserWindow } from 'electron';
+import * as Sentry from '@sentry/electron';
+import { autoUpdater } from 'electron-updater';
+import * as os from 'os';
+import types from 'root/mutation-types';
+import PlayerWindow from './player';
+import ControllerWindow from './controller';
+
+const DEBUG = process.env.DEBUG ? true : false;
+const MAC = os.type() === 'Darwin';
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({ dsn: process.env.SENTRY_DSN });
+}
+
+if (MAC) app.dock.hide();
+
+app.on('ready', () => {
+  const menuTemplate: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: 'Polidium',
+      submenu: [
+        {
+          label: 'Check for Updates...',
+          click() { autoUpdater.checkForUpdates(); }
+        },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    }
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+
+  autoUpdater.on('update-downloaded', () => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Restart', 'Later'],
+      title: 'Update ready',
+      message: 'Update downloaded. Restart now?'
+    }).then(result => {
+      if (result.response === 0) autoUpdater.quitAndInstall();
+    });
+  });
+
+  const player = new PlayerWindow();
+  const controller = new ControllerWindow();
+
+  const trayIcon = nativeImage.createFromPath(__dirname + '/img/tray_icon.png');
+  const tray = new Tray(trayIcon);
+
+  tray.on('click', (_event, bounds) => {
+    controller.toggle(bounds.x);
+  });
+
+  player.show();
+
+  ipcMain.on(types.CONNECT_STATE, (event) => {
+    event.returnValue = store.state;
+  });
+
+  ipcMain.on(types.CONNECT_COMMIT, (_event, typeName: string, payload: string) => {
+    if (DEBUG) console.log(typeName, payload);
+    player.win.webContents.send(types.CONNECT_COMMIT, typeName, payload);
+    controller.win.webContents.send(types.CONNECT_COMMIT, typeName, payload);
+
+    if (typeName === types.QUIT) app.quit();
+
+    if (typeName === types.SET_CLICKTHROUGH) {
+      const parsedPayload = JSON.parse(payload);
+      player.win.setIgnoreMouseEvents(parsedPayload.clickThrough);
+      player.win.setAlwaysOnTop(parsedPayload.clickThrough);
+      if (MAC) player.win.setVisibleOnAllWorkspaces(parsedPayload.clickThrough);
+    }
+
+    if (typeName === types.RESIZE_PLAYER) {
+      const parsedPayload = JSON.parse(payload);
+
+      if (parsedPayload.mode) {
+        player.win.focus();
+      } else {
+        player.win.blur();
+      }
+
+      player.win.setIgnoreMouseEvents(!parsedPayload.mode);
+      player.win.setAlwaysOnTop(true);
+      if (MAC) player.win.setVisibleOnAllWorkspaces(true);
+      player.win.setResizable(parsedPayload.mode);
+      player.win.setMovable(parsedPayload.mode);
+      if (MAC) player.win.setHasShadow(parsedPayload.mode);
+    }
+  });
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "build": {
     "appId": "net.nekobato.polidium",
-    "files": ["!src"],
+    "files": [
+      "!src"
+    ],
     "asar": true,
     "linux": {
       "arch": [
@@ -84,19 +86,22 @@
     "style-loader": "^4.0.0",
     "stylus": "^0.64.0",
     "stylus-loader": "^8.1.1",
+    "ts-loader": "^9.5.0",
+    "typescript": "^5.4.5",
     "url-loader": "^4.1.1",
     "vue": "^3.5.16",
     "vue-loader": "^17.4.2",
     "vue-template-compiler": "^2.7.16",
     "vuex": "^4.1.0",
     "webpack": "^5.99.9",
+    "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",
     "webpack-merge": "^6.0.1",
     "xss": "^1.0.15"
   },
   "dependencies": {
-    "xss": "^1.0.15"
+    "@sentry/electron": "^3.0.8",
     "electron-updater": "^2.23.3",
-    "@sentry/electron": "^3.0.8"
+    "xss": "^1.0.15"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "./app",
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": "./app/src",
+    "paths": {
+      "root/*": ["*"],
+      "main/*": ["main/*"],
+      "renderer/*": ["renderer/*"]
+    }
+  },
+  "include": ["app/src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -11,6 +11,11 @@ module.exports = {
       {
         test: /\.node$/,
         loader: 'node-loader'
+      },
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
       }
     ]
   },
@@ -29,7 +34,7 @@ module.exports = {
     })
   ],
   resolve: {
-    extensions: ['.js', '.json', '.node'],
+    extensions: ['.ts', '.js', '.json', '.node'],
     modules: [
       path.join(__dirname, 'app/node_modules')
     ],


### PR DESCRIPTION
## Summary
- start migrating project to TypeScript
- add `tsconfig.json`
- include `ts-loader` in main webpack config
- convert `app/src/main/index.js` to TypeScript
- install ts-loader and typescript

## Testing
- `npm test` *(fails: merge is not a function in karma.conf.js)*
- `npx webpack --progress --config ./webpack.main.config.js` *(fails to compile due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68401b80707c832aaa35bdccfa8d1d13