### PR TITLE
Use Element Plus tree for queue list

### DIFF
--- a/app/src/renderer/Controller/FileController.vue
+++ b/app/src/renderer/Controller/FileController.vue
@@ -3,24 +3,29 @@
     <div class="empty-queue" v-show="queueIsEmpty">
       <span class="grey-text">Drop Movie files? Here</span>
     </div>
-    <ul class="collection" ref="queueList" v-show="!queueIsEmpty">
-      <li
-        class="collection-item"
-        v-for="(queue, index) in queues"
-        :key="index"
-        :class="{ selected: index === playPointer }"
-        @click.prevent="play(index)"
-      >
-        <i class="material-icons playlist-deleter" @click.prevent="remove(index)">close</i>
-        <span class="truncate">{{ queue.name }}</span>
-      </li>
-      <li class="clear-all">
-        <div class="clear-btn" @click="clear">
-          <i class="material-icons">clear</i>
-          <span class="clear-text">Clear Playlist</span>
-        </div>
-      </li>
-    </ul>
+    <el-tree
+      class="queue-tree"
+      v-show="!queueIsEmpty"
+      :data="treeData"
+      node-key="id"
+      draggable
+      :highlight-current="true"
+      :current-node-key="playPointer ?? undefined"
+      :allow-drop="allowDrop"
+      @node-click="onNodeClick"
+      @node-drop="onNodeDrop"
+    >
+      <template #default="{ data }">
+        <span class="truncate">{{ data.name }}</span>
+        <i class="material-icons playlist-deleter" @click.stop.prevent="removeByData(data)">close</i>
+      </template>
+    </el-tree>
+    <div class="clear-all" v-show="!queueIsEmpty">
+      <div class="clear-btn" @click="clear">
+        <i class="material-icons">clear</i>
+        <span class="clear-text">Clear Playlist</span>
+      </div>
+    </div>
     <div class="blue-grey darken-2 center video-controller">
       <button class="btn pause-btn" v-if="isPlaying" @click="pause">
         <i class="material-icons white-text">pause</i>
@@ -46,14 +51,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useVideoStore } from 'renderer/store/modules/video'
 import ipc from 'renderer/ipc'
 import * as types from 'root/mutation-types'
-import Sortable, { type SortableEvent } from 'sortablejs'
+import type { NodeDropType } from 'element-plus/es/components/tree/src/tree.type'
+import type Node from 'element-plus/es/components/tree/src/model/node'
 
 const videoStore = useVideoStore()
-const queueList = ref<HTMLElement | null>(null)
 
 const queues = computed(() => videoStore.queues)
 const playPointer = computed(() => videoStore.playPointer)
@@ -68,6 +73,39 @@ const currentTime = computed(() => {
   const percentage = (video.value.currentTime / video.value.duration) * 100
   return isNaN(percentage) ? 0 : percentage
 })
+
+const treeData = computed(() =>
+  queues.value.map((q, i) => ({ ...q, id: i }))
+)
+
+function playByData (data: { name: string; path: string }) {
+  const index = queues.value.findIndex(q => q === data)
+  play(index)
+}
+
+function removeByData (data: { name: string; path: string }) {
+  const index = queues.value.findIndex(q => q === data)
+  remove(index)
+}
+
+function allowDrop (_dragging: Node, _drop: Node, type: NodeDropType) {
+  return type !== 'inner'
+}
+
+function onNodeClick (_data: any, node: Node) {
+  const index = (node.data as any).id
+  play(index)
+}
+
+function onNodeDrop (draggingNode: Node, dropNode: Node, type: NodeDropType) {
+  const oldIndex = (draggingNode.data as any).id
+  let newIndex = (dropNode.data as any).id
+  if (type === 'after') newIndex += 1
+  if (oldIndex < newIndex) newIndex -= 1
+  if (type !== 'inner') {
+    ipc.commit(types.SORT_QUEUE, { oldIndex, newIndex })
+  }
+}
 
 function play (index: number) {
   ipc.commit(types.VIDEO_SELECT, { index })
@@ -92,44 +130,33 @@ function clear () {
 function inputCurrentTime (value: number) {
   ipc.commit(types.VIDEO_SEEK, { percentage: value })
 }
-
-onMounted(() => {
-  Sortable.create(queueList.value!, {
-    onUpdate: (e: SortableEvent) => {
-      ipc.commit(types.SORT_QUEUE, {
-        oldIndex: e.oldIndex,
-        newIndex: e.newIndex
-      })
-    }
-  })
-})
 </script>
 
 <style lang="scss" scoped>
 .play-controller {
   text-align: center;
 }
-.collection {
-  width: 100%;
-}
 .playlist-deleter {
   right: 5px;
   display: none;
   position: absolute;
 }
-.collection-item {
+.queue-tree {
+  width: 100%;
+}
+.queue-tree .el-tree-node__content {
   position: relative;
   cursor: pointer;
 }
-.collection-item:hover .playlist-deleter {
+.queue-tree .el-tree-node__content:hover .playlist-deleter {
   display: inline-block;
   color: #9e9e9e;
 }
-.collection-item.selected {
+.queue-tree .is-current > .el-tree-node__content {
   background: #22b4e2;
   color: #fff;
 }
-.collection-item.selected .playlist-deleter {
+.queue-tree .is-current > .el-tree-node__content .playlist-deleter {
   color: #fff;
 }
 .clear-all {


### PR DESCRIPTION
## Summary
- replace queued file list with draggable Element Plus tree
- handle node click/drop and deletion
- adjust styling for new tree

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script: test:e2e)*

------
https://chatgpt.com/codex/tasks/task_e_684112190e60832a89706f00270ba9ce