### PR TITLE
Add vueuse and migrate local storage to useStorage

### DIFF
--- a/app/src/renderer/store/modules/settings.ts
+++ b/app/src/renderer/store/modules/settings.ts
@@ -1,48 +1,72 @@
 import { defineStore } from 'pinia'
+import { useStorage } from '@vueuse/core'
+import { computed } from 'vue'
 
-function getSettingsFromLocalStrage () {
-  return localStorage.settings ? JSON.parse(localStorage.settings) : {
+interface SettingsState {
+  player: {
+    mode: string
+    opacity: number
+    clickThrough: boolean
+    resizeMode: boolean
+  }
+}
+
+export const useSettingsStore = defineStore('settings', () => {
+  const state = useStorage<SettingsState>('settings', {
     player: {
       mode: 'video-player',
       opacity: 0.05,
       clickThrough: true,
       resizeMode: false
     }
-  }
-}
+  })
 
-export const useSettingsStore = defineStore('settings', {
-  state: () => getSettingsFromLocalStrage(),
-  actions: {
-    changeMode (mode: string) {
-      this.player.mode = mode
-    },
-    changeOpacity (newOpacity: number) {
-      this.player.opacity = newOpacity
-      localStorage.setItem('settings', JSON.stringify(this.$state))
-    },
-    setClickthrough (payload: { clickThrough: boolean }) {
-      this.player.clickThrough = payload.clickThrough
-    },
-    reload () {
-      window.location.reload()
-    },
-    reset () {
-      localStorage.removeItem('queues')
-      localStorage.removeItem('settings')
-      window.location.reload()
-    },
-    openUrl () {
-      this.player.mode = 'web-player'
-      localStorage.setItem('settings', JSON.stringify(this.$state))
-    },
-    videoSelect () {
-      this.player.mode = 'video-player'
-      localStorage.setItem('settings', JSON.stringify(this.$state))
-    },
-    resizePlayer (payload: { mode: boolean }) {
-      this.player.resizeMode = payload.mode
-      this.player.clickThrough = !payload.mode
-    }
+  const player = computed(() => state.value.player)
+
+  function changeMode (mode: string) {
+    state.value.player.mode = mode
+  }
+
+  function changeOpacity (newOpacity: number) {
+    state.value.player.opacity = newOpacity
+  }
+
+  function setClickthrough (payload: { clickThrough: boolean }) {
+    state.value.player.clickThrough = payload.clickThrough
+  }
+
+  function reload () {
+    window.location.reload()
+  }
+
+  function reset () {
+    localStorage.removeItem('queues')
+    localStorage.removeItem('settings')
+    window.location.reload()
+  }
+
+  function openUrl () {
+    state.value.player.mode = 'web-player'
+  }
+
+  function videoSelect () {
+    state.value.player.mode = 'video-player'
+  }
+
+  function resizePlayer (payload: { mode: boolean }) {
+    state.value.player.resizeMode = payload.mode
+    state.value.player.clickThrough = !payload.mode
+  }
+
+  return {
+    player,
+    changeMode,
+    changeOpacity,
+    setClickthrough,
+    reload,
+    reset,
+    openUrl,
+    videoSelect,
+    resizePlayer
   }
 })

--- a/app/src/renderer/store/modules/video.ts
+++ b/app/src/renderer/store/modules/video.ts
@@ -1,70 +1,93 @@
 import { defineStore } from 'pinia'
+import { useStorage } from '@vueuse/core'
+import { ref, reactive } from 'vue'
 
-function getQeueusFromLocalStrage () {
-  return localStorage.queues ? JSON.parse(localStorage.queues) : []
-}
+export const useVideoStore = defineStore('video', () => {
+  const queues = useStorage<Array<{ name: string; path: string }>>('queues', [])
+  const playPointer = ref<number | null>(null)
+  const video = reactive({
+    duration: 0,
+    currentTime: 0,
+    seekPercentage: 0,
+    isPlaying: false,
+    switch: false // switch play/pause control by controller
+  })
 
-export const useVideoStore = defineStore('video', {
-  state: () => ({
-    queues: getQeueusFromLocalStrage() as Array<{ name: string; path: string }>,
-    playPointer: null as number | null,
-    video: {
-      duration: 0,
-      currentTime: 0,
-      seekPercentage: 0,
-      isPlaying: false,
-      switch: false // switch play/pause control by controller
+  function dropFile (payload: { file: { name: string; path: string } }) {
+    queues.value.push(payload.file)
+  }
+
+  function pauseFile () {
+    video.switch = false
+  }
+
+  function resumeFile () {
+    video.switch = true
+  }
+
+  function selectVideo (payload: { index: number }) {
+    playPointer.value = payload.index
+  }
+
+  function removeQueue (payload: { index: number }) {
+    queues.value.splice(payload.index, 1)
+  }
+
+  function clearQueues () {
+    queues.value = []
+  }
+
+  function sortQueue (payload: { oldIndex: number; newIndex: number }) {
+    const newRow = queues.value.splice(payload.newIndex, 1, null as any)[0]
+    queues.value.splice(payload.newIndex, 1, queues.value[payload.oldIndex])
+    queues.value.splice(payload.oldIndex, 1, newRow)
+  }
+
+  function videoCanplay (payload: { duration: number }) {
+    video.duration = payload.duration
+    video.switch = true
+  }
+
+  function videoTimeupdate (payload: { currentTime: number }) {
+    video.currentTime = payload.currentTime
+  }
+
+  function videoSeek (payload: { percentage: number }) {
+    video.seekPercentage = payload.percentage
+  }
+
+  function videoPlayed () {
+    video.isPlaying = true
+    video.switch = true
+  }
+
+  function videoPaused () {
+    video.isPlaying = false
+    video.switch = false
+  }
+
+  function videoEnded () {
+    if (queues.value[(playPointer.value ?? -1) + 1]) {
+      playPointer.value = (playPointer.value ?? -1) + 1
     }
-  }),
-  actions: {
-    dropFile (payload: { file: { name: string; path: string } }) {
-      this.queues.push(payload.file)
-      localStorage.setItem('queues', JSON.stringify(this.queues))
-    },
-    pauseFile () {
-      this.video.switch = false
-    },
-    resumeFile () {
-      this.video.switch = true
-    },
-    selectVideo (payload: { index: number }) {
-      this.playPointer = payload.index
-    },
-    removeQueue (payload: { index: number }) {
-      this.queues.splice(payload.index, 1)
-      localStorage.setItem('queues', JSON.stringify(this.queues))
-    },
-    clearQueues () {
-      this.queues = []
-    },
-    sortQueue (payload: { oldIndex: number; newIndex: number }) {
-      const newRow = this.queues.splice(payload.newIndex, 1, null as any)[0]
-      this.queues.splice(payload.newIndex, 1, this.queues[payload.oldIndex])
-      this.queues.splice(payload.oldIndex, 1, newRow)
-      localStorage.setItem('queues', JSON.stringify(this.queues))
-    },
-    videoCanplay (payload: { duration: number }) {
-      this.video.duration = payload.duration
-      this.video.switch = true
-    },
-    videoTimeupdate (payload: { currentTime: number }) {
-      this.video.currentTime = payload.currentTime
-    },
-    videoSeek (payload: { percentage: number }) {
-      this.video.seekPercentage = payload.percentage
-    },
-    videoPlayed () {
-      this.video.isPlaying = true
-      this.video.switch = true
-    },
-    videoPaused () {
-      this.video.isPlaying = false
-      this.video.switch = false
-    },
-    videoEnded () {
-      if (this.queues[(this.playPointer ?? -1) + 1]) {
-        this.playPointer = (this.playPointer ?? -1) + 1
-      }
-    }
+  }
+
+  return {
+    queues,
+    playPointer,
+    video,
+    dropFile,
+    pauseFile,
+    resumeFile,
+    selectVideo,
+    removeQueue,
+    clearQueues,
+    sortQueue,
+    videoCanplay,
+    videoTimeupdate,
+    videoSeek,
+    videoPlayed,
+    videoPaused,
+    videoEnded
   }
 })

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@iconify/vue": "^4.3.0",
     "@sentry/electron": "^3.0.8",
+    "@vueuse/core": "^10.9.0",
     "electron-updater": "^2.23.3",
     "element-plus": "^2.9.11",
     "vue-router": "^4.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@sentry/electron':
         specifier: ^3.0.8
         version: 3.0.8
+      '@vueuse/core':
+        specifier: ^10.9.0
+        version: 10.11.1(vue@3.5.16(typescript@5.8.3))
       electron-updater:
         specifier: ^2.23.3
         version: 2.23.3
@@ -556,6 +559,9 @@ packages:
   '@types/web-bluetooth@0.0.16':
     resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
 
+  '@types/web-bluetooth@0.0.20':
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -618,11 +624,20 @@ packages:
   '@vue/shared@3.5.16':
     resolution: {integrity: sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==}
 
+  '@vueuse/core@10.11.1':
+    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
   '@vueuse/core@9.13.0':
     resolution: {integrity: sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==}
 
+  '@vueuse/metadata@10.11.1':
+    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
+
   '@vueuse/metadata@9.13.0':
     resolution: {integrity: sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==}
+
+  '@vueuse/shared@10.11.1':
+    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
 
   '@vueuse/shared@9.13.0':
     resolution: {integrity: sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==}
@@ -2645,6 +2660,8 @@ snapshots:
 
   '@types/web-bluetooth@0.0.16': {}
 
+  '@types/web-bluetooth@0.0.20': {}
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 22.15.29
@@ -2741,6 +2758,16 @@ snapshots:
 
   '@vue/shared@3.5.16': {}
 
+  '@vueuse/core@10.11.1(vue@3.5.16(typescript@5.8.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.1
+      '@vueuse/shared': 10.11.1(vue@3.5.16(typescript@5.8.3))
+      vue-demi: 0.14.10(vue@3.5.16(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@vueuse/core@9.13.0(vue@3.5.16(typescript@5.8.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.16
@@ -2751,7 +2778,16 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@vueuse/metadata@10.11.1': {}
+
   '@vueuse/metadata@9.13.0': {}
+
+  '@vueuse/shared@10.11.1(vue@3.5.16(typescript@5.8.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.16(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@vueuse/shared@9.13.0(vue@3.5.16(typescript@5.8.3))':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@vueuse/core` dependency
- refactor settings and video pinia stores to use `useStorage`

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684114cf41d0832aa7068ae9a141b7dc