### PR TITLE
Fix Vite build alias

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,7 @@ import {
 import * as Sentry from "@sentry/electron";
 import { autoUpdater } from "electron-updater";
 import * as os from "os";
-import * as types from "@/mutation-types";
+import * as types from "../mutation-types";
 import PlayerWindow from "./player";
 import ControllerWindow from "./controller";
 import { join } from "path";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,8 @@ export default defineConfig({
   resolve: {
     alias: {
       renderer: resolve(__dirname, "src/renderer"),
-      root: resolve(__dirname, "src")
+      root: resolve(__dirname, "src"),
+      "@": resolve(__dirname, "src")
     }
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add `@` alias so vite build can resolve imports
- adjust main process to use relative path

## Testing
- `pnpm run lint`
- `pnpm vite build`

------
https://chatgpt.com/codex/tasks/task_e_684125986b50832a82dad4ae8868c0ba