### PR TITLE
Fix Sentry env var usage in renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ pnpm install
 pnpm run dev
 ```
 
-Sentry を利用する場合は、環境変数 `SENTRY_DSN` に DSN を設定してください。
+Sentry を利用する場合は、環境変数 `VITE_SENTRY_DSN` に DSN を設定してください。

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -7,8 +7,10 @@ import { useSettingsStore } from "./modules/settings";
 
 const ipc = (window as any).electronAPI;
 
-if (process.env.SENTRY_DSN) {
-  Sentry.init({ dsn: process.env.SENTRY_DSN });
+const { VITE_SENTRY_DSN } = import.meta.env;
+
+if (VITE_SENTRY_DSN) {
+  Sentry.init({ dsn: VITE_SENTRY_DSN });
 }
 
 export const pinia = createPinia();


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_SENTRY_DSN` instead of `process.env` in renderer
- mention `VITE_SENTRY_DSN` in the README

## Testing
- `pnpm test` *(fails: Missing script `test:e2e`)*

------
https://chatgpt.com/codex/tasks/task_e_6841285623fc832a9365628a65b16dcc