### PR TITLE
Switch controller views via vue-router

### DIFF
--- a/src/renderer/Controller/Controller.vue
+++ b/src/renderer/Controller/Controller.vue
@@ -12,6 +12,7 @@
         :options="options"
         size="small"
         class="my-toggle"
+        @change="switchView"
       >
         <template #default="{ item }">
           <Icon :icon="item.icon" class="icon" />
@@ -20,32 +21,49 @@
       </el-segmented>
       <button
         class="waves-effect waves-teal btn-flat my-settings"
-        @click="switchView('Settings')"
-        :class="{ 'my-on': currentView === 'Settings' }"
+        @click="switchView('/controller/settings')"
+        :class="{ 'my-on': isSettings }"
       >
         <Icon icon="mingcute:settings-6-line" />
       </button>
     </div>
-    <component :is="currentView" />
+    <router-view />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch, computed } from "vue";
+import { useRouter, useRoute } from "vue-router";
 import { Icon } from "@iconify/vue";
 import ipc from "@/renderer/ipc";
 import * as types from "@/mutation-types";
 
+const router = useRouter();
+const route = useRoute();
+
 const options = [
-  { label: "file", value: "FileController", icon: "mingcute:file-line" },
-  { label: "Web", value: "WebController", icon: "mingcute:world-2-line" }
+  { label: "file", value: "/controller/file", icon: "mingcute:file-line" },
+  { label: "Web", value: "/controller/web", icon: "mingcute:world-2-line" }
 ];
 
-const currentView = ref("FileController");
+const currentView = ref(options[0].value);
 
-function switchView(viewName: "FileController" | "WebController" | "Settings") {
-  currentView.value = viewName;
+// sync currentView with current route
+watch(
+  () => route.path,
+  (path) => {
+    if (path.startsWith("/controller/web")) currentView.value = "/controller/web";
+    else if (path.startsWith("/controller/file")) currentView.value = "/controller/file";
+    else currentView.value = "";
+  },
+  { immediate: true }
+);
+
+function switchView(path: string) {
+  router.push(path);
 }
+
+const isSettings = computed(() => route.path.startsWith("/controller/settings"));
 
 function onDragOver(_e: DragEvent) {
   return false;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -6,20 +6,32 @@ import { createRouter, createWebHistory } from "vue-router";
 import App from "./App.vue";
 import Player from "./Player/Player.vue";
 import Controller from "./Controller/Controller.vue";
+import FileController from "./Controller/FileController.vue";
+import WebController from "./Controller/WebController.vue";
+import Settings from "./Controller/Settings.vue";
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: "/player", component: Player },
-    { path: "/controller", component: Controller }
+    {
+      path: "/controller",
+      component: Controller,
+      children: [
+        { path: "", redirect: "/controller/file" },
+        { path: "file", component: FileController },
+        { path: "web", component: WebController },
+        { path: "settings", component: Settings }
+      ]
+    }
   ]
 });
 
 const app = createApp(App).use(pinia).use(ElementPlus).use(router);
 
-// Support '#player' and '#controller' hash navigation
+// Support '#player' and '#controller' hash navigation including child paths
 const hash = window.location.hash.replace("#", "");
-if (hash === "player" || hash === "controller") {
+if (hash === "player" || hash.startsWith("controller")) {
   router.replace("/" + hash);
 }
 


### PR DESCRIPTION
## Summary
- leverage vue-router child routes for Controller
- render nested controller routes with `<router-view>`
- support more controller hash URLs

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684132843a4c832a917ef667ee7101b0