### PR TITLE
Use contextBridge for clipboard

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, clipboard } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   send(channel: string, ...args: unknown[]) {
@@ -9,5 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   invoke(channel: string, ...args: unknown[]) {
     return ipcRenderer.invoke(channel, ...args)
+  },
+  readClipboardText() {
+    return clipboard.readText()
   }
 })

--- a/src/renderer/Controller/WebController.vue
+++ b/src/renderer/Controller/WebController.vue
@@ -33,7 +33,6 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import ipc from "@/renderer/ipc";
-import { clipboard } from "electron";
 import xss from "xss";
 import * as types from "@/mutation-types";
 import { useSettingsStore } from "@/renderer/store/modules/settings";
@@ -61,7 +60,7 @@ function submitURL() {
 
 function tryPasteClipboard(e: KeyboardEvent) {
   if (e.metaKey !== true) return;
-  url.value = clipboard.readText();
+  url.value = ipc.readClipboardText();
 }
 
 function inputClickThrough(value: boolean) {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -5,5 +5,8 @@ const ipc = (window as any).electronAPI;
 export default {
   commit(type: string, payload: unknown) {
     ipc.send(types.CONNECT_COMMIT, type, JSON.stringify(payload));
+  },
+  readClipboardText() {
+    return ipc.readClipboardText();
   }
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,6 +2,7 @@ export interface ElectronAPI {
   send(channel: string, ...args: unknown[]): void
   on(channel: string, listener: (...args: unknown[]) => void): void
   invoke(channel: string, ...args: unknown[]): Promise<unknown>
+  readClipboardText(): string
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- read clipboard text through preload bridge instead of importing Electron in Vue component

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684135387908832a9c2962ff5f5614aa