### PR TITLE
Switch to Mingcute icons via Iconify

### DIFF
--- a/src/renderer/Controller/FileController.vue
+++ b/src/renderer/Controller/FileController.vue
@@ -17,25 +17,25 @@
     >
       <template #default="{ data }">
         <span class="truncate">{{ data.name }}</span>
-        <i
-          class="material-icons playlist-deleter"
+        <Icon
+          icon="mingcute:close-line"
+          class="playlist-deleter"
           @click.stop.prevent="removeByData(data)"
-          >close</i
-        >
+        />
       </template>
     </el-tree>
     <div class="clear-all" v-show="!queueIsEmpty">
       <div class="clear-btn" @click="clear">
-        <i class="material-icons">clear</i>
+        <Icon icon="mingcute:delete-2-line" class="icon" />
         <span class="clear-text">Clear Playlist</span>
       </div>
     </div>
     <div class="blue-grey darken-2 center video-controller">
       <button class="btn pause-btn" v-if="isPlaying" @click="pause">
-        <i class="material-icons white-text">pause</i>
+        <Icon icon="mingcute:pause-line" class="white-text" />
       </button>
       <button class="btn play-btn" v-if="!isPlaying" @click="resume">
-        <i class="material-icons white-text">play_arrow</i>
+        <Icon icon="mingcute:play-line" class="white-text" />
       </button>
       <div class="seekbar-container">
         <el-slider
@@ -56,6 +56,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { Icon } from "@iconify/vue";
 import { useVideoStore } from "@/renderer/store/modules/video";
 import ipc from "@/renderer/ipc";
 import * as types from "@/mutation-types";
@@ -176,10 +177,10 @@ function inputCurrentTime(value: number) {
   color: #666;
 }
 .clear-all .clear-text,
-.clear-all .material-icons {
+.clear-all .icon {
   display: block;
 }
-.clear-all .material-icons {
+.clear-all .icon {
   font-size: 24px;
 }
 .playlist {

--- a/src/renderer/Controller/Settings.vue
+++ b/src/renderer/Controller/Settings.vue
@@ -21,23 +21,23 @@
     </div>
     <div class="row center resize">
       <div class="btn" @click="resizePlayer">
-        <i class="material-icons left">transform</i>
+        <Icon icon="mingcute:transformation-line" class="left" />
         <span>resize player</span>
       </div>
     </div>
     <div class="row center disruptive">
       <div class="btn blue" @click="reload">
-        <i class="material-icons left">refresh</i>
+        <Icon icon="mingcute:refresh-2-line" class="left" />
         <span>reload</span>
       </div>
       <div class="btn blue" @click="reset">
-        <i class="material-icons left">settings_applications</i>
+        <Icon icon="mingcute:settings-6-line" class="left" />
         <span>reset settings</span>
       </div>
     </div>
     <div class="row center disruptive">
       <div class="btn red" @click="quit">
-        <i class="material-icons left">close</i>
+        <Icon icon="mingcute:close-line" class="left" />
         <span>quit</span>
       </div>
     </div>
@@ -46,6 +46,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { Icon } from "@iconify/vue";
 import { useSettingsStore } from "@/renderer/store/modules/settings";
 import ipc from "@/renderer/ipc";
 import * as types from "@/mutation-types";

--- a/src/renderer/Player/ResizeMode.vue
+++ b/src/renderer/Player/ResizeMode.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="resize">
     <div class="restore" @click="onRestore">
-      <i class="material-icons">settings_backup_restore</i>
+      <Icon icon="mingcute:restore-line" class="icon" />
       <span class="text">Restore</span>
     </div>
   </div>
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import ipc from "@/renderer/ipc";
 import * as types from "@/mutation-types";
+import { Icon } from "@iconify/vue";
 
 function onRestore() {
   ipc.commit(types.RESIZE_PLAYER, { mode: false });
@@ -43,7 +44,7 @@ function onRestore() {
   color: #888;
 }
 
-.restore .material-icons {
+.restore .icon {
   font-size: 48px;
 }
 


### PR DESCRIPTION
## Summary
- replace material icons with `<Icon>` from iconify/vue
- use Mingcute icons for buttons and actions

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684137d926d4832a92a1da1bb2cdddbc