### PR TITLE
Enable file playback via IPC

### DIFF
--- a/src/mutation-types.ts
+++ b/src/mutation-types.ts
@@ -5,6 +5,7 @@ export const CONNECT_SCREEN = 'CONNECT_SCREEN'
 export const DROP_FILE = 'DROP_FILE'
 
 export const VIDEO_SELECT = 'VIDEO_SELECT'
+export const PLAY_FILE = 'PLAY_FILE'
 export const PAUSE_FILE = 'PAUSE_FILE'
 export const RESUME_FILE = 'RESUME_FILE'
 export const REMOVE_QUEUE = 'REMOVE_QUEUE'

--- a/src/renderer/Controller/FileController.vue
+++ b/src/renderer/Controller/FileController.vue
@@ -84,6 +84,8 @@ import { computed } from "vue";
 import { Icon } from "@iconify/vue";
 import { useVideoStore } from "@/renderer/store/modules/video";
 import { useSettingsStore } from "@/renderer/store/modules/settings";
+import ipc from "@/renderer/ipc";
+import * as types from "@/mutation-types";
 import type { NodeDropType } from "element-plus/es/components/tree/src/tree.type";
 import type Node from "element-plus/es/components/tree/src/model/node";
 
@@ -136,16 +138,19 @@ function onNodeDrop(draggingNode: Node, dropNode: Node, type: NodeDropType) {
 }
 
 function play(index: number) {
+  const file = queues.value[index];
   videoStore.selectVideo({ index });
+  ipc.commit(types.VIDEO_SELECT, { index });
+  ipc.commit(types.PLAY_FILE, { file });
   settingsStore.videoSelect();
 }
 
 function resume() {
-  videoStore.resumeFile();
+  ipc.commit(types.RESUME_FILE, {});
 }
 
 function pause() {
-  videoStore.pauseFile();
+  ipc.commit(types.PAUSE_FILE, {});
 }
 
 function remove(index: number) {
@@ -157,7 +162,7 @@ function clear() {
 }
 
 function inputCurrentTime(value: number) {
-  videoStore.videoSeek({ percentage: value });
+  ipc.commit(types.VIDEO_SEEK, { percentage: value });
 }
 </script>
 

--- a/src/renderer/Player/VideoPlayer.vue
+++ b/src/renderer/Player/VideoPlayer.vue
@@ -19,14 +19,8 @@ import { useVideoStore } from "@/renderer/store/modules/video";
 const videoStore = useVideoStore();
 const videoEl = ref<HTMLVideoElement | null>(null);
 
-const queues = computed(() => videoStore.queues);
-const playPointer = computed(() => videoStore.playPointer);
-const videoSource = computed(() => {
-  const pointer = playPointer.value;
-  return pointer !== null && queues.value[pointer]
-    ? queues.value[pointer].path
-    : "";
-});
+const currentFile = computed(() => videoStore.currentFile);
+const videoSource = computed(() => currentFile.value ? currentFile.value.path : "");
 const video = computed(() => videoStore.video);
 
 watch(

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -23,6 +23,7 @@ const commitMap: Record<string, (payload: any) => void> = {
   [types.DROP_FILE]: (payload) => videoStore.dropFile(payload),
   [types.PAUSE_FILE]: () => videoStore.pauseFile(),
   [types.RESUME_FILE]: () => videoStore.resumeFile(),
+  [types.PLAY_FILE]: (payload) => videoStore.setCurrentFile(payload),
   [types.VIDEO_SELECT]: (payload) => {
     videoStore.selectVideo(payload);
     settingsStore.videoSelect();

--- a/src/renderer/store/modules/video.ts
+++ b/src/renderer/store/modules/video.ts
@@ -5,6 +5,7 @@ import { ref, reactive } from 'vue'
 export const useVideoStore = defineStore('video', () => {
   const queues = useStorage<Array<{ name: string; path: string }>>('queues', [])
   const playPointer = ref<number | null>(null)
+  const currentFile = ref<{ name: string; path: string } | null>(null)
   const video = reactive({
     duration: 0,
     currentTime: 0,
@@ -27,6 +28,7 @@ export const useVideoStore = defineStore('video', () => {
 
   function selectVideo (payload: { index: number }) {
     playPointer.value = payload.index
+    currentFile.value = queues.value[payload.index] ?? null
   }
 
   function removeQueue (payload: { index: number }) {
@@ -69,12 +71,18 @@ export const useVideoStore = defineStore('video', () => {
   function videoEnded () {
     if (queues.value[(playPointer.value ?? -1) + 1]) {
       playPointer.value = (playPointer.value ?? -1) + 1
+      currentFile.value = queues.value[playPointer.value] ?? null
     }
+  }
+
+  function setCurrentFile (payload: { file: { name: string; path: string } | null }) {
+    currentFile.value = payload.file
   }
 
   return {
     queues,
     playPointer,
+    currentFile,
     video,
     dropFile,
     pauseFile,
@@ -88,6 +96,7 @@ export const useVideoStore = defineStore('video', () => {
     videoSeek,
     videoPlayed,
     videoPaused,
-    videoEnded
+    videoEnded,
+    setCurrentFile
   }
 })


### PR DESCRIPTION
## Summary
- add `PLAY_FILE` mutation type
- sync current file via IPC and update VideoPlayer
- control playback through IPC calls from FileController

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script `test:e2e`)*

------
https://chatgpt.com/codex/tasks/task_e_684143b4c4b8832a9eae421495f1edf1