### PR TITLE
Use router for switching player modes

### DIFF
--- a/src/renderer/Player/Player.vue
+++ b/src/renderer/Player/Player.vue
@@ -1,22 +1,33 @@
 <template>
   <div class="player" :style="playerStyle">
-    <component :is="settings.mode" />
+    <router-view />
     <resize-mode v-show="settings.resizeMode" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import type { CSSProperties } from "vue";
+import { useRouter } from "vue-router";
 import { useSettingsStore } from "@/renderer/store/modules/settings";
 import ResizeMode from "./ResizeMode.vue";
 
 const settingsStore = useSettingsStore();
 const settings = computed(() => settingsStore.player);
+const router = useRouter();
 const playerStyle = computed<CSSProperties>(() => ({
   opacity: settings.value.resizeMode ? 1 : settings.value.opacity,
   pointerEvents: settings.value.clickThrough ? "none" : "auto"
 }));
+
+watch(
+  () => settings.value.mode,
+  (mode) => {
+    if (mode === "video-player") router.push("/player/file");
+    else if (mode === "web-player") router.push("/player/web");
+  },
+  { immediate: true }
+);
 </script>
 
 <style lang="scss">

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -6,6 +6,8 @@ import { pinia } from "./store";
 import { createRouter, createWebHistory } from "vue-router";
 import App from "./App.vue";
 import Player from "./Player/Player.vue";
+import VideoPlayer from "./Player/VideoPlayer.vue";
+import WebPlayer from "./Player/WebPlayer.vue";
 import Controller from "./Controller/Controller.vue";
 import FileController from "./Controller/FileController.vue";
 import WebController from "./Controller/WebController.vue";
@@ -14,7 +16,15 @@ import Settings from "./Controller/Settings.vue";
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: "/player", component: Player },
+    {
+      path: "/player",
+      component: Player,
+      children: [
+        { path: "", redirect: "/player/file" },
+        { path: "file", component: VideoPlayer },
+        { path: "web", component: WebPlayer }
+      ]
+    },
     {
       path: "/controller",
       component: Controller,


### PR DESCRIPTION
## Summary
- switch Player.vue to use `<router-view>` and sync route with mode
- create nested routes for VideoPlayer and WebPlayer

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script `test:e2e`)*

------
https://chatgpt.com/codex/tasks/task_e_6841463997fc832aa08e7eef22cf6c5c