### PR TITLE
Enable IPC URL open

### DIFF
--- a/src/renderer/Controller/WebController.vue
+++ b/src/renderer/Controller/WebController.vue
@@ -33,6 +33,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import ipc from "@/renderer/ipc";
+import * as types from "@/mutation-types";
 import xss from "xss";
 import { useSettingsStore } from "@/renderer/store/modules/settings";
 import { useWebStore } from "@/renderer/store/modules/web";
@@ -58,6 +59,7 @@ function submitURL() {
   }
   webStore.openUrl({ src: encodedURL.value });
   settingsStore.openUrl();
+  ipc.commit(types.OPEN_URL, { src: encodedURL.value });
 }
 
 function tryPasteClipboard(e: KeyboardEvent) {


### PR DESCRIPTION
## Summary
- allow WebController to open URLs via IPC so the player window loads them

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script: test:e2e)*

------
https://chatgpt.com/codex/tasks/task_e_68414cea1b44832a96365c6fc9ad080a