### PR TITLE
Use WebContentsView for web player overlay

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,6 +116,17 @@ function createWindows() {
         player.win!.setMovable(parsedPayload.mode);
         if (MAC) player.win!.setHasShadow(parsedPayload.mode);
       }
+
+      if (typeName === types.OPEN_URL) {
+        const parsed = JSON.parse(payload);
+        player.openUrl(parsed.src);
+      }
+
+      if (typeName === types.CHANGE_MODE) {
+        const mode = JSON.parse(payload);
+        if (mode === 'video-player') player.hideWebView();
+        if (mode === 'web-player') player.showWebView();
+      }
     }
   );
 }

--- a/src/renderer/Player/WebPlayer.vue
+++ b/src/renderer/Player/WebPlayer.vue
@@ -1,13 +1,9 @@
 <template>
-  <webview class="web-player" nodeintegration :src="web.src"></webview>
+  <div class="web-player"></div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
-import { useWebStore } from "@/renderer/store/modules/web";
-
-const webStore = useWebStore();
-const web = computed(() => webStore);
+// Web page contents are handled in the main process via WebContentsView
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary
- overlay WebContentsView on the Player window instead of using `<webview>`
- update main process to manage WebContentsView when mode changes and when opening URLs
- cleanup `WebPlayer.vue`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68426461e64c832aa2c8255047e8eda9