### PR TITLE
feat: improve video playback controls and electron security

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="ja" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: media:; media-src 'self' media: blob:; font-src 'self' data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src 'none'; base-uri 'self'; frame-src 'none'"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Polidium</title>
   </head>

--- a/main/controller.ts
+++ b/main/controller.ts
@@ -11,7 +11,7 @@ export default class ControllerWindow {
   constructor() {
     this.win = new BrowserWindow({
       width: WINDOW_WIDTH,
-      height: 360,
+      height: 420,
       show: DEBUG ? true : false,
       resizable: false,
       frame: false,
@@ -42,7 +42,7 @@ export default class ControllerWindow {
       this.win.loadURL(devUrl + "#/controller");
       this.win.webContents.openDevTools({ mode: "detach" });
     } else {
-      this.win.loadURL("file://" + __dirname + "/../dist/index.html#/controller");
+      this.win.loadURL("polidium://app/index.html#/controller");
     }
   }
 
@@ -68,7 +68,7 @@ export default class ControllerWindow {
   destroy() {
     if (this.win && !this.win.isDestroyed()) {
       this.win.removeAllListeners();
-      this.win.close();
+      this.win.destroy();
     }
   }
 }

--- a/main/index.ts
+++ b/main/index.ts
@@ -199,7 +199,14 @@ async function listVideoFilesInFolder(folderPath: string, recursive: boolean): P
   async function visit(directoryPath: string): Promise<void> {
     if (files.length >= MAX_FOLDER_VIDEO_FILES) return;
 
-    const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+    let entries: Array<fs.Dirent>;
+    try {
+      entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+    } catch (error) {
+      console.warn("[Main] Skipping unreadable folder:", directoryPath, error);
+      return;
+    }
+
     for (const entry of entries) {
       if (files.length >= MAX_FOLDER_VIDEO_FILES) return;
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,16 +1,23 @@
-import { app, Tray, nativeImage, ipcMain, Menu, dialog, BrowserWindow, net, protocol, globalShortcut } from "electron";
+import { app, Tray, nativeImage, ipcMain, Menu, dialog, BrowserWindow, net, protocol, globalShortcut, session } from "electron";
 import * as Sentry from "@sentry/electron";
 import { autoUpdater } from "electron-updater";
 import * as os from "os";
 import * as types from "../src/mutation-types";
 import PlayerWindow from "./player";
 import ControllerWindow from "./controller";
-import { join } from "path";
+import * as fs from "fs";
+import * as path from "path";
 import { saveWindowBounds, loadWindowBounds } from "./windowBounds";
 import { pathToFileURL } from "url";
+import { randomUUID } from "crypto";
 
 const DEBUG = process.env.DEBUG ? true : false;
 const MAC = os.type() === "Darwin";
+const APP_PROTOCOL = "polidium";
+const APP_PROTOCOL_HOST = "app";
+const MEDIA_PROTOCOL = "media";
+const MAX_FOLDER_VIDEO_FILES = 500;
+const VIDEO_FILE_EXTENSIONS = new Set([".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v", ".3gp", ".flv", ".wmv"]);
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({ dsn: process.env.SENTRY_DSN });
@@ -26,19 +33,188 @@ let ipcHandlers: Array<() => void> = [];
 let currentGlobalShortcut: string | null = null;
 let savedOpacity: number = 0.05;
 let isPlayerHidden: boolean = false;
+let protocolHandlersRegistered: boolean = false;
+const mediaFileTokens = new Map<string, string>();
 
 // media://xxxx
 protocol.registerSchemesAsPrivileged([
   {
-    scheme: "media",
+    scheme: APP_PROTOCOL,
     privileges: {
+      standard: true,
       secure: true,
       supportFetchAPI: true,
-      bypassCSP: true,
+    },
+  },
+  {
+    scheme: MEDIA_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
       stream: true,
     },
   },
 ]);
+
+/**
+ * Returns the production app entry URL for trusted renderer checks.
+ */
+function getProductionAppEntryFileUrl(): string {
+  return pathToFileURL(path.join(__dirname, "../dist/index.html")).href;
+}
+
+/**
+ * Checks whether a renderer URL belongs to this packaged app.
+ */
+function isTrustedAppUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    const devUrl = process.env.VITE_DEV_SERVER_URL;
+
+    if (devUrl && parsedUrl.origin === new URL(devUrl).origin) return true;
+    if (parsedUrl.protocol === `${APP_PROTOCOL}:` && parsedUrl.hostname === APP_PROTOCOL_HOST) return true;
+
+    return url.startsWith(getProductionAppEntryFileUrl());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks whether an IPC event came from one of the trusted app windows.
+ */
+function isTrustedAppIpcEvent(event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent): boolean {
+  if (!event.senderFrame) return false;
+  if (event.senderFrame !== event.sender.mainFrame) return false;
+
+  const fromPlayerWindow = event.sender === player?.win?.webContents;
+  const fromControllerWindow = event.sender === controller?.win?.webContents;
+
+  return (fromPlayerWindow || fromControllerWindow) && isTrustedAppUrl(event.senderFrame.url);
+}
+
+/**
+ * Resolves a requested app protocol URL to a file inside dist.
+ */
+function resolveAppProtocolPath(requestUrl: string): string | null {
+  const parsedUrl = new URL(requestUrl);
+  if (parsedUrl.hostname !== APP_PROTOCOL_HOST) return null;
+
+  const distRoot = path.resolve(__dirname, "../dist");
+  const rawPathname = decodeURIComponent(parsedUrl.pathname || "/index.html");
+  const pathname = rawPathname === "/" ? "/index.html" : rawPathname;
+  const filePath = path.resolve(distRoot, `.${pathname}`);
+
+  if (filePath !== distRoot && !filePath.startsWith(`${distRoot}${path.sep}`)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+/**
+ * Serves packaged renderer assets from the app custom protocol.
+ */
+async function handleAppProtocolRequest(req: Request): Promise<Response> {
+  const filePath = resolveAppProtocolPath(req.url);
+  if (!filePath) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  try {
+    return await net.fetch(pathToFileURL(filePath).href);
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+}
+
+/**
+ * Creates an opaque media URL for an explicitly selected local file.
+ */
+function createMediaUrlForFile(filePath: string, fileName: string): string {
+  if (!path.isAbsolute(filePath)) {
+    throw new Error("Media file path must be absolute");
+  }
+
+  mediaFileTokens.clear();
+  const token = randomUUID();
+  mediaFileTokens.set(token, filePath);
+
+  const safeName = encodeURIComponent(fileName || path.basename(filePath));
+  return `${MEDIA_PROTOCOL}://${token}/${safeName}`;
+}
+
+/**
+ * Serves only token-approved media files.
+ */
+async function handleMediaProtocolRequest(req: Request): Promise<Response> {
+  const parsedUrl = new URL(req.url);
+  const filePath = mediaFileTokens.get(parsedUrl.hostname);
+
+  if (!filePath) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  try {
+    return await net.fetch(pathToFileURL(filePath).href, { headers: req.headers });
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+}
+
+/**
+ * Registers custom protocol handlers once per app lifetime.
+ */
+function registerProtocolHandlers(): void {
+  if (protocolHandlersRegistered) return;
+
+  protocol.handle(APP_PROTOCOL, handleAppProtocolRequest);
+  protocol.handle(MEDIA_PROTOCOL, handleMediaProtocolRequest);
+  protocolHandlersRegistered = true;
+}
+
+/**
+ * Denies browser permission prompts from remote content by default.
+ */
+function configureSessionSecurity(): void {
+  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(false);
+  });
+}
+
+/**
+ * Returns whether a path looks like a supported video file.
+ */
+function isSupportedVideoFilePath(filePath: string): boolean {
+  return VIDEO_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Recursively lists supported videos under a folder with a fixed result cap.
+ */
+async function listVideoFilesInFolder(folderPath: string, recursive: boolean): Promise<Array<{ name: string; path: string }>> {
+  const files: Array<{ name: string; path: string }> = [];
+
+  async function visit(directoryPath: string): Promise<void> {
+    if (files.length >= MAX_FOLDER_VIDEO_FILES) return;
+
+    const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (files.length >= MAX_FOLDER_VIDEO_FILES) return;
+
+      const entryPath = path.join(directoryPath, entry.name);
+      if (entry.isDirectory() && recursive) {
+        await visit(entryPath);
+      } else if (entry.isFile() && isSupportedVideoFilePath(entryPath)) {
+        files.push({ name: entry.name, path: entryPath });
+      }
+    }
+  }
+
+  await visit(folderPath);
+  return files.sort((a, b) => a.name.localeCompare(b.name));
+}
 
 function cleanupWindows() {
   // IPCハンドラーをクリーンアップ
@@ -47,22 +223,27 @@ function cleanupWindows() {
 
   // ウィンドウのクリーンアップ
   if (player) {
-    player.win?.removeAllListeners();
+    player.destroy();
     player = null;
   }
   if (controller) {
-    controller.win?.removeAllListeners();
+    controller.destroy();
     controller = null;
   }
 
   // Trayのクリーンアップ
   if (tray) {
+    tray.destroy();
     tray = null;
   }
 }
 
 // ファイルパスを取得するためのipcハンドラー
-ipcMain.handle("get-file-path", async (_event, fileInfo) => {
+ipcMain.handle("get-file-path", async (event, fileInfo) => {
+  if (!isTrustedAppIpcEvent(event)) {
+    return { success: false, error: "Forbidden" };
+  }
+
   console.log("[Main] get-file-path called with:", fileInfo);
 
   // fileInfoからパスを取得
@@ -106,13 +287,42 @@ ipcMain.handle("get-file-path", async (_event, fileInfo) => {
 });
 
 // ファイル選択ダイアログを開くためのipcハンドラー
-ipcMain.handle("show-open-dialog", async (_event, options) => {
+ipcMain.handle("show-open-dialog", async (event, options) => {
+  if (!isTrustedAppIpcEvent(event)) {
+    return { canceled: true, filePaths: [] };
+  }
+
   try {
     const result = await dialog.showOpenDialog(options);
     return result;
   } catch (error) {
     console.error("[Main] Error opening dialog:", error);
     return { canceled: true, filePaths: [] };
+  }
+});
+
+// フォルダ内の動画ファイルを列挙するためのipcハンドラー
+ipcMain.handle("list-video-files", async (event, payload: { folderPath?: string; recursive?: boolean }) => {
+  if (!isTrustedAppIpcEvent(event)) {
+    return { success: false, files: [], error: "Forbidden" };
+  }
+
+  const folderPath = payload.folderPath;
+  if (!folderPath || !path.isAbsolute(folderPath)) {
+    return { success: false, files: [], error: "Invalid folder path" };
+  }
+
+  try {
+    const stats = await fs.promises.stat(folderPath);
+    if (!stats.isDirectory()) {
+      return { success: false, files: [], error: "Selected path is not a folder" };
+    }
+
+    const files = await listVideoFilesInFolder(folderPath, payload.recursive ?? true);
+    return { success: true, files, truncated: files.length >= MAX_FOLDER_VIDEO_FILES };
+  } catch (error) {
+    console.error("[Main] Error listing video files:", error);
+    return { success: false, files: [], error: String(error) };
   }
 });
 
@@ -201,7 +411,7 @@ function createWindows() {
     player.win.setBounds(savedBounds);
   }
 
-  const trayIcon = nativeImage.createFromPath(join(__dirname, "../img", "trayIconTemplate.png"));
+  const trayIcon = nativeImage.createFromPath(path.join(__dirname, "../img", "trayIconTemplate.png"));
   tray = new Tray(trayIcon);
 
   tray.on("click", (_event, bounds) => {
@@ -238,18 +448,19 @@ function createWindows() {
     if (DEBUG) console.log(typeName, payload);
 
     if (!player || !controller) return;
+    if (!isTrustedAppIpcEvent(event)) {
+      console.warn("[Main] Rejected IPC from untrusted sender:", event.senderFrame?.url);
+      return;
+    }
 
     // 送信元のウィンドウを識別
-    const isFromPlayer = event.sender === player.win?.webContents || event.sender === player.webView?.webContents;
+    const isFromPlayer = event.sender === player.win?.webContents;
     const isFromController = event.sender === controller.win?.webContents;
 
     // 送信元でないウィンドウにのみイベントを転送
     if (isFromController) {
       // コントローラーからのイベントはプレイヤーに送信
       player.win?.webContents.send(types.CONNECT_COMMIT, typeName, payload);
-      if (player.webView?.webContents) {
-        player.webView.webContents.send(types.CONNECT_COMMIT, typeName, payload);
-      }
     } else if (isFromPlayer) {
       // プレイヤーからのイベントはコントローラーに送信
       controller.win?.webContents.send(types.CONNECT_COMMIT, typeName, payload);
@@ -350,15 +561,13 @@ function createWindows() {
           // ファイル情報を取得
           const filePath = parsedPayload.file.path || "";
           const fileName = parsedPayload.file.name || "";
+          const startTime = typeof parsedPayload.startTime === "number" ? parsedPayload.startTime : 0;
 
           // パスが有効かどうかチェック
           if (filePath) {
             console.log(`[Main] Processing video file: ${parsedPayload.name}, path: ${filePath}`);
 
-            // media://プロトコルを使用してパスを変換
-            const mediaPath = pathToFileURL(filePath).href.replace(/^file:\/\//, "");
-            console.log(`[Main] Converted media path: ${mediaPath}`);
-            const mediaUrl = `media://${mediaPath}`;
+            const mediaUrl = createMediaUrlForFile(filePath, fileName);
 
             // ファイル情報をmedia://プロトコルでプレイヤーに送信
             console.log(`[Main] Sending file to player: ${parsedPayload.name}, ${mediaUrl}`);
@@ -370,6 +579,7 @@ function createWindows() {
                   name: fileName,
                   path: mediaUrl,
                 },
+                startTime,
               }),
             );
           } else {
@@ -387,14 +597,11 @@ function createWindows() {
   // 既存のリスナーを削除してから新しいリスナーを追加
   ipcMain.removeAllListeners(types.CONNECT_COMMIT);
   ipcMain.on(types.CONNECT_COMMIT, ipcHandler);
-
-  protocol.handle("media", (req) => {
-    const filePath = decodeURIComponent(req.url.slice("media://".length));
-    return net.fetch(pathToFileURL(filePath).href);
-  });
 }
 
 app.whenReady().then(() => {
+  registerProtocolHandlers();
+  configureSessionSecurity();
   createWindows();
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindows();

--- a/main/player.ts
+++ b/main/player.ts
@@ -3,6 +3,18 @@ import { join } from "path";
 
 const DEBUG = !!process.env.DEBUG;
 
+/**
+ * Checks whether a URL is safe to load as remote browser content.
+ */
+function isAllowedRemoteUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export default class PlayerWindow {
   win: BrowserWindow | null;
   webView: WebContentsView | null = null;
@@ -46,7 +58,7 @@ export default class PlayerWindow {
       this.win.loadURL(devUrl + "#/player");
       this.win.webContents.openDevTools({ mode: "detach" });
     } else {
-      this.win.loadURL("file://" + __dirname + "/../dist/index.html#/player");
+      this.win.loadURL("polidium://app/index.html#/player");
     }
 
     this.win.on("closed", () => {
@@ -73,7 +85,7 @@ export default class PlayerWindow {
     // BrowserWindowのクリーンアップ
     if (this.win && !this.win.isDestroyed()) {
       this.win.removeAllListeners();
-      this.win.close();
+      this.win.destroy();
       this.win = null;
     }
   }
@@ -103,41 +115,57 @@ export default class PlayerWindow {
     }
   }
 
+  /**
+   * Creates an isolated view for untrusted web content.
+   */
+  private createWebView() {
+    const webView = new WebContentsView({
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    this.win?.removeAllListeners("resize");
+    this.win?.on("resize", () => this.updateViewBounds());
+
+    webView.webContents.on("did-finish-load", () => {
+      console.log("[Player] WebContentsView did-finish-load, applying pointer-events");
+      this.updateWebViewPointerEvents();
+    });
+
+    webView.webContents.on("will-navigate", (event, url) => {
+      if (!isAllowedRemoteUrl(url)) {
+        event.preventDefault();
+      }
+    });
+
+    webView.webContents.on("will-redirect", (event, url) => {
+      if (!isAllowedRemoteUrl(url)) {
+        event.preventDefault();
+      }
+    });
+
+    // target="_blank"のリンクをデフォルトブラウザで開く
+    webView.webContents.setWindowOpenHandler(({ url }) => {
+      if (isAllowedRemoteUrl(url)) {
+        shell.openExternal(url);
+      }
+      return { action: "deny" };
+    });
+
+    this.setupWebViewNavigationEvents(webView);
+
+    return webView;
+  }
+
   showWebView() {
     if (!this.currentUrl) return;
 
     // 既存のWebContentsViewがある場合は再利用
     if (!this.webView) {
-      this.webView = new WebContentsView({
-        webPreferences: {
-          preload: join(__dirname, "preload.js"),
-          contextIsolation: true,
-          nodeIntegration: false,
-        },
-      });
-
-      // resizeイベントリスナーを一度だけ登録
-      this.win?.removeAllListeners("resize");
-      this.win?.on("resize", () => this.updateViewBounds());
-
-      // did-finish-loadイベントでpointer-eventsを設定
-      this.webView.webContents.once("did-finish-load", () => {
-        console.log("[Player] WebContentsView did-finish-load (showWebView), applying pointer-events");
-        this.updateWebViewPointerEvents();
-      });
-
-      // ナビゲーションイベントを設定
-      this.setupWebViewNavigationEvents();
-
-      // target="_blank"のリンクをデフォルトブラウザで開く
-      this.webView.webContents.setWindowOpenHandler(({ url }) => {
-        // HTTPとHTTPSのみ許可（セキュリティ対策）
-        if (url.startsWith("http:") || url.startsWith("https:")) {
-          shell.openExternal(url);
-        }
-        return { action: "deny" }; // 新しいElectronウィンドウの作成を拒否
-      });
-
+      this.webView = this.createWebView();
       this.webView.webContents.loadURL(this.currentUrl);
     }
 
@@ -146,36 +174,11 @@ export default class PlayerWindow {
   }
 
   openUrl(url: string) {
+    if (!isAllowedRemoteUrl(url)) return;
+
     this.currentUrl = url;
     if (!this.webView) {
-      this.webView = new WebContentsView({
-        webPreferences: {
-          preload: join(__dirname, "preload.js"),
-          contextIsolation: true,
-          nodeIntegration: false,
-        },
-      });
-      // resizeイベントリスナーを一度だけ登録
-      this.win?.removeAllListeners("resize");
-      this.win?.on("resize", () => this.updateViewBounds());
-
-      // did-finish-loadイベントでpointer-eventsを設定
-      this.webView.webContents.once("did-finish-load", () => {
-        console.log("[Player] WebContentsView did-finish-load (openUrl), applying pointer-events");
-        this.updateWebViewPointerEvents();
-      });
-
-      // ナビゲーションイベントを設定
-      this.setupWebViewNavigationEvents();
-
-      // target="_blank"のリンクをデフォルトブラウザで開く
-      this.webView.webContents.setWindowOpenHandler(({ url }) => {
-        // HTTPとHTTPSのみ許可（セキュリティ対策）
-        if (url.startsWith("http:") || url.startsWith("https:")) {
-          shell.openExternal(url);
-        }
-        return { action: "deny" }; // 新しいElectronウィンドウの作成を拒否
-      });
+      this.webView = this.createWebView();
     }
     this.attachView();
     this.webView!.webContents.loadURL(url);
@@ -253,10 +256,10 @@ export default class PlayerWindow {
     this.updateWebViewPointerEvents();
   }
 
-  private setupWebViewNavigationEvents() {
-    if (!this.webView || this.webView.webContents.isDestroyed()) return;
+  private setupWebViewNavigationEvents(webView = this.webView) {
+    if (!webView || webView.webContents.isDestroyed()) return;
 
-    const webContents = this.webView.webContents;
+    const webContents = webView.webContents;
 
     // ナビゲーション状態の更新を通知する関数
     const notifyNavigationState = () => {
@@ -326,6 +329,8 @@ export default class PlayerWindow {
       () => webContents.removeAllListeners("did-stop-loading"),
       () => webContents.removeAllListeners("did-navigate"),
       () => webContents.removeAllListeners("did-navigate-in-page"),
+      () => webContents.removeAllListeners("will-navigate"),
+      () => webContents.removeAllListeners("will-redirect"),
     ];
 
     // 初期状態を通知

--- a/src/Controller/FileController.vue
+++ b/src/Controller/FileController.vue
@@ -1,24 +1,62 @@
 <template>
   <div class="playlist">
+    <el-alert
+      v-if="videoError"
+      class="video-error"
+      type="error"
+      :title="videoError"
+      show-icon
+      closable
+      @close="videoStore.clearVideoError"
+    />
+
     <div class="video-actions">
       <div class="action-buttons">
-        <el-button class="prev-button" type="primary" circle :disabled="!canPlayPrevious" @click="playPrevious">
+        <el-button class="prev-button" type="primary" circle :disabled="!canPlayPrevious" title="Previous" aria-label="Previous" @click="playPrevious">
           <Icon icon="mingcute:skip-previous-line" class="white-text" />
         </el-button>
-        <el-button class="pause-button" v-if="isPlaying" type="primary" size="large" circle @click="pause">
+        <el-button class="pause-button" v-if="isPlaying" type="primary" size="large" circle title="Pause" aria-label="Pause" @click="pause">
           <Icon icon="mingcute:pause-line" class="white-text" />
         </el-button>
-        <el-button class="play-button" v-if="!isPlaying" type="primary" size="large" circle :disabled="!canPlay" @click="resume">
+        <el-button class="play-button" v-if="!isPlaying" type="primary" size="large" circle :disabled="!canPlay" title="Play" aria-label="Play" @click="resume">
           <Icon icon="mingcute:play-line" class="white-text" />
         </el-button>
-        <el-button class="next-button" type="primary" circle :disabled="!canPlayNext" @click="playNext">
+        <el-button class="next-button" type="primary" circle :disabled="!canPlayNext" title="Next" aria-label="Next" @click="playNext">
           <Icon icon="mingcute:skip-forward-line" class="white-text" />
         </el-button>
       </div>
+
       <div class="seekbar-container">
         <el-slider class="seekbar" id="seekbar" :min="0" :max="100" :model-value="currentTime" @input="inputCurrentTime" show-tooltip />
       </div>
       <el-tag type="info" class="duration" size="small">{{ videoRemaining }}</el-tag>
+
+      <div class="playback-tools">
+        <el-button class="tool-button" size="small" :class="{ active: playbackMode !== 'sequence' }" :title="playbackModeLabel" :aria-label="playbackModeLabel" @click="cyclePlaybackMode">
+          <Icon :icon="playbackModeIcon" />
+        </el-button>
+
+        <el-popover placement="bottom" width="220px" trigger="click" popper-class="volume-popover">
+          <template #reference>
+            <el-button class="tool-button" size="small" :class="{ active: muted || volume === 0 }" title="Volume" aria-label="Volume">
+              <Icon :icon="volumeIcon" />
+            </el-button>
+          </template>
+          <div class="volume-panel">
+            <div class="volume-header">
+              <span>Volume</span>
+              <el-button class="mute-toggle" text size="small" @click="toggleMuted">
+                {{ muted ? "Unmute" : "Mute" }}
+              </el-button>
+            </div>
+            <el-slider :model-value="volumePercentage" :min="0" :max="100" @input="inputVolume" />
+          </div>
+        </el-popover>
+
+        <el-select class="speed-select" size="small" :model-value="playbackRate" title="Playback speed" aria-label="Playback speed" @change="inputPlaybackRate">
+          <el-option v-for="rate in playbackRates" :key="rate" :label="`${rate}x`" :value="rate" />
+        </el-select>
+      </div>
     </div>
 
     <div class="empty-queue" v-show="queueIsEmpty">
@@ -39,8 +77,8 @@
     >
       <template #default="{ data }">
         <div class="tree-node-content">
-          <span class="truncate">{{ data.name }}</span>
-          <el-button plain size="small" class="playlist-deleter" text @click.stop.prevent="removeByData(data)">
+          <span class="truncate" :title="data.name">{{ data.name }}</span>
+          <el-button plain size="small" class="playlist-deleter" text title="Remove" aria-label="Remove" @click.stop.prevent="removeByData(data)">
             <Icon icon="mingcute:close-line" />
           </el-button>
         </div>
@@ -48,10 +86,29 @@
     </el-tree>
 
     <div class="list-actions">
-      <el-button type="primary" @click="openFileDialog" round size="small" class="add-video-btn">
-        <Icon icon="mingcute:add-line" />
-      </el-button>
-      <el-button v-show="!queueIsEmpty" class="clear-btn" @click="clear" size="small" round>
+      <div class="add-actions">
+        <el-button type="primary" @click="openFileDialog" round size="small" class="add-video-btn" title="Add videos" aria-label="Add videos">
+          <Icon icon="mingcute:add-line" />
+        </el-button>
+        <el-button @click="openFolderDialog" round size="small" title="Add folder" aria-label="Add folder">
+          <Icon icon="mingcute:folder-open-line" />
+        </el-button>
+        <el-dropdown trigger="click" :disabled="!videoStore.hasRecentFiles" @command="handleRecentCommand">
+          <el-button round size="small" :disabled="!videoStore.hasRecentFiles" title="Recent files" aria-label="Recent files">
+            <Icon icon="mingcute:time-line" />
+          </el-button>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item v-for="file in recentFiles" :key="file.path" :command="file">
+                {{ file.name }}
+              </el-dropdown-item>
+              <el-dropdown-item divided command="clear">Clear recent</el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+      </div>
+
+      <el-button v-show="!queueIsEmpty" class="clear-btn" @click="clear" size="small" round title="Clear playlist" aria-label="Clear playlist">
         <Icon icon="mingcute:delete-2-line" class="icon" />
       </el-button>
     </div>
@@ -68,16 +125,47 @@ import * as types from "@/mutation-types";
 import type { NodeDropType } from "element-plus/es/components/tree/src/tree.type";
 import type Node from "element-plus/es/components/tree/src/model/node";
 
+interface QueueItem {
+  name: string;
+  path: string;
+}
+
+type PlaybackMode = "sequence" | "repeat-all" | "repeat-one" | "shuffle";
+type RecentCommand = QueueItem | "clear";
+
+const playbackRates = [0.5, 0.75, 1, 1.25, 1.5, 2];
+const playbackModeOrder: Array<PlaybackMode> = ["sequence", "repeat-all", "repeat-one", "shuffle"];
+const playbackModeMeta: Record<PlaybackMode, { label: string; icon: string }> = {
+  sequence: { label: "Sequence", icon: "mingcute:playlist-line" },
+  "repeat-all": { label: "Repeat all", icon: "mingcute:repeat-line" },
+  "repeat-one": { label: "Repeat one", icon: "mingcute:repeat-one-line" },
+  shuffle: { label: "Shuffle", icon: "mingcute:shuffle-2-line" },
+};
+
 const videoStore = useVideoStore();
 const settingsStore = useSettingsStore();
 
 const queues = computed(() => videoStore.queues);
+const recentFiles = computed(() => videoStore.recentFiles);
 const playPointer = computed(() => videoStore.playPointer);
 const queueIsEmpty = computed(() => queues.value.length === 0);
 const video = computed(() => videoStore.video);
+const videoError = computed(() => video.value.error);
 const isPlaying = computed(() => video.value.isPlaying);
+const playbackMode = computed(() => videoStore.playbackMode);
+const playbackModeIcon = computed(() => playbackModeMeta[playbackMode.value].icon);
+const playbackModeLabel = computed(() => playbackModeMeta[playbackMode.value].label);
+const volume = computed(() => videoStore.volume);
+const muted = computed(() => videoStore.muted);
+const playbackRate = computed(() => videoStore.playbackRate);
+const volumePercentage = computed(() => Math.round(volume.value * 100));
+const volumeIcon = computed(() => {
+  if (muted.value || volume.value === 0) return "mingcute:volume-mute-line";
+  if (volume.value < 0.5) return "mingcute:volume-line";
+  return "mingcute:volume-fill";
+});
 const videoRemaining = computed(() => {
-  const remainSeconds = Math.floor(video.value.duration - video.value.currentTime);
+  const remainSeconds = Math.max(0, Math.floor(video.value.duration - video.value.currentTime));
   return `${Math.floor(remainSeconds / 60)}:${("0" + (remainSeconds % 60)).slice(-2)}`;
 });
 const currentTime = computed(() => {
@@ -87,21 +175,12 @@ const currentTime = computed(() => {
 
 const treeData = computed(() => queues.value.map((q, i) => ({ ...q, id: i })));
 
-const canPlay = computed(() => {
-  return queues.value.length > 0 && videoStore.playPointer !== undefined;
-});
-
-const canPlayPrevious = computed(() => {
-  return queues.value.length > 0 && videoStore.playPointer && videoStore.playPointer > 0;
-});
-
-const canPlayNext = computed(() => {
-  return queues.value.length > 0 && videoStore.playPointer && videoStore.playPointer < queues.value.length - 1;
-});
+const canPlay = computed(() => queues.value.length > 0);
+const canPlayPrevious = computed(() => getPreviousIndex() !== null);
+const canPlayNext = computed(() => getManualNextIndex() !== null);
 
 function removeByData(data: { name: string; path: string; id: number }) {
-  const index = data.id;
-  remove(index);
+  remove(data.id);
 }
 
 function allowDrop(_dragging: Node, _drop: Node, type: NodeDropType) {
@@ -109,7 +188,6 @@ function allowDrop(_dragging: Node, _drop: Node, type: NodeDropType) {
 }
 
 function onNodeClick(_data: any, node: Node) {
-  console.log("Node clicked:", _data, node);
   const index = (node.data as any).id;
   play(index);
 }
@@ -124,35 +202,42 @@ function onNodeDrop(draggingNode: Node, dropNode: Node, type: NodeDropType) {
   }
 }
 
-function play(index: number) {
+function play(index: number, options: { restorePosition?: boolean } = {}) {
   const file = queues.value[index];
-  console.log("Playing file:", file);
   if (!file) {
-    console.error("Invalid file");
+    videoStore.setVideoError({ message: "Selected video is no longer available." });
     return;
   }
 
-  // まずはビデオ選択状態を更新
   videoStore.selectVideo({ index });
+  videoStore.addRecentFiles([file]);
   ipc.commit(types.VIDEO_SELECT, { index });
 
-  // 次にビデオプレイヤーモードに切り替え
   settingsStore.changeMode("video-player");
   ipc.commit(types.CHANGE_MODE, "video-player");
 
-  // ファイル情報をIPCを通して送信
-  const fileInfo = {
-    name: file.name,
-    // storeに保存されているパスは既に絶対パスなので、そのまま使用
-    path: file.path || "",
-  };
-
-  // IPCでファイル情報を送信（メインプロセスでパス解決される）
-  ipc.commit(types.PLAY_FILE, { file: fileInfo });
+  const startTime = options.restorePosition === false ? 0 : videoStore.getPlaybackPosition(file.path);
+  ipc.commit(types.PLAY_FILE, {
+    file: {
+      name: file.name,
+      path: file.path || "",
+    },
+    startTime,
+  });
   settingsStore.videoSelect();
 }
 
 function resume() {
+  if (playPointer.value === null) {
+    play(0);
+    return;
+  }
+
+  if (!videoStore.currentFile) {
+    play(playPointer.value);
+    return;
+  }
+
   ipc.commit(types.RESUME_FILE, {});
 }
 
@@ -161,15 +246,13 @@ function pause() {
 }
 
 function playPrevious() {
-  if (canPlayPrevious.value) {
-    videoStore.selectVideo({ index: videoStore.playPointer! - 1 });
-  }
+  const previousIndex = getPreviousIndex();
+  if (previousIndex !== null) play(previousIndex);
 }
 
 function playNext() {
-  if (canPlayNext.value) {
-    videoStore.selectVideo({ index: videoStore.playPointer! + 1 });
-  }
+  const nextIndex = getManualNextIndex();
+  if (nextIndex !== null) play(nextIndex);
 }
 
 function remove(index: number) {
@@ -184,41 +267,150 @@ function inputCurrentTime(value: number) {
   ipc.commit(types.VIDEO_SEEK, { percentage: value });
 }
 
+function cyclePlaybackMode() {
+  const currentIndex = playbackModeOrder.indexOf(playbackMode.value);
+  const nextMode = playbackModeOrder[(currentIndex + 1) % playbackModeOrder.length];
+  videoStore.setPlaybackMode(nextMode);
+}
+
+function inputVolume(value: number | number[]) {
+  const nextValue = Array.isArray(value) ? value[0] : value;
+  const nextVolume = nextValue / 100;
+  videoStore.setVolume(nextVolume);
+  ipc.commit(types.VIDEO_VOLUME, { volume: nextVolume });
+}
+
+function toggleMuted() {
+  const nextMuted = !muted.value;
+  videoStore.setMuted(nextMuted);
+  ipc.commit(types.VIDEO_MUTED, { muted: nextMuted });
+}
+
+function inputPlaybackRate(rate: number) {
+  videoStore.setPlaybackRate(rate);
+  ipc.commit(types.VIDEO_PLAYBACK_RATE, { playbackRate: rate });
+}
+
+function addFilesToQueue(files: Array<QueueItem>) {
+  if (files.length === 0) return;
+  videoStore.addQueues(files);
+}
+
 async function openFileDialog() {
   try {
-    // Electronのネイティブダイアログを使用
     const result = await ipc.showOpenDialog({
       properties: ["openFile", "multiSelections"],
       filters: [{ name: "Video Files", extensions: ["mp4", "webm", "mov", "avi", "mkv", "m4v", "3gp", "flv", "wmv"] }],
     });
 
     if (!result.canceled && result.filePaths) {
-      result.filePaths.forEach((filePath: string) => {
-        // ファイル名をパスから抽出
-        const fileName = filePath.split("/").pop() || filePath.split("\\").pop() || "Unknown";
-
-        const fileInfo = {
-          name: fileName,
+      addFilesToQueue(
+        result.filePaths.map((filePath: string) => ({
+          name: filePath.split("/").pop() || filePath.split("\\").pop() || "Unknown",
           path: filePath,
-        };
-        videoStore.addQueue(fileInfo);
-      });
+        })),
+      );
     }
   } catch (error) {
-    console.error("Error opening file dialog:", error);
+    videoStore.setVideoError({ message: `Could not open files: ${String(error)}` });
   }
 }
 
-ipc.on(types.VIDEO_CANPLAY, (...args: unknown[]) => {
-  const data = args[0] as { duration: number };
-  console.log("[VideoPlayer] Video can play:", data);
-  videoStore.videoCanplay({ duration: data.duration });
-});
+async function openFolderDialog() {
+  try {
+    const result = await ipc.showOpenDialog({
+      properties: ["openDirectory"],
+    });
 
-ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
-  const data = args[0] as { currentTime: number };
-  console.log("[VideoPlayer] Video update:", data);
-  videoStore.videoTimeupdate({ currentTime: data.currentTime });
+    if (result.canceled || !result.filePaths?.[0]) return;
+
+    const response = await ipc.invoke("list-video-files", {
+      folderPath: result.filePaths[0],
+      recursive: true,
+    });
+
+    if (!response.success) {
+      videoStore.setVideoError({ message: response.error || "Could not read the selected folder." });
+      return;
+    }
+
+    if (response.files.length === 0) {
+      videoStore.setVideoError({ message: "No supported videos were found in the selected folder." });
+      return;
+    }
+
+    addFilesToQueue(response.files);
+    if (response.truncated) {
+      videoStore.setVideoError({ message: "Only the first 500 supported videos were added from this folder." });
+    }
+  } catch (error) {
+    videoStore.setVideoError({ message: `Could not add folder: ${String(error)}` });
+  }
+}
+
+function handleRecentCommand(command: RecentCommand) {
+  if (command === "clear") {
+    videoStore.clearRecentFiles();
+    return;
+  }
+
+  videoStore.addQueue(command);
+}
+
+function getShuffleIndex(currentIndex: number): number | null {
+  if (queues.value.length === 0) return null;
+  if (queues.value.length === 1) return currentIndex;
+
+  const candidates = queues.value.map((_file, index) => index).filter((index) => index !== currentIndex);
+  return candidates[Math.floor(Math.random() * candidates.length)] ?? null;
+}
+
+function getPreviousIndex(): number | null {
+  const currentIndex = playPointer.value;
+  if (currentIndex === null || queues.value.length === 0) return null;
+  if (playbackMode.value === "shuffle") return getShuffleIndex(currentIndex);
+  if (currentIndex > 0) return currentIndex - 1;
+  if (playbackMode.value === "repeat-all" && queues.value.length > 1) return queues.value.length - 1;
+  return null;
+}
+
+function getManualNextIndex(): number | null {
+  const currentIndex = playPointer.value;
+  if (currentIndex === null || queues.value.length === 0) return null;
+  if (playbackMode.value === "shuffle") return getShuffleIndex(currentIndex);
+  if (currentIndex + 1 < queues.value.length) return currentIndex + 1;
+  if (playbackMode.value === "repeat-all" && queues.value.length > 1) return 0;
+  return null;
+}
+
+function getNextAutoplayIndex(): number | null {
+  const currentIndex = playPointer.value;
+  if (currentIndex === null || queues.value.length === 0) return null;
+
+  if (playbackMode.value === "repeat-one") return currentIndex;
+
+  if (playbackMode.value === "shuffle") {
+    return getShuffleIndex(currentIndex);
+  }
+
+  const nextIndex = currentIndex + 1;
+  if (nextIndex < queues.value.length) return nextIndex;
+
+  return playbackMode.value === "repeat-all" ? 0 : null;
+}
+
+function playAfterEnded() {
+  const nextIndex = getNextAutoplayIndex();
+  if (nextIndex === null) return;
+
+  play(nextIndex, { restorePosition: false });
+}
+
+ipc.on(types.CONNECT_COMMIT, (...args: unknown[]) => {
+  const [typeName] = args as [string, string];
+  if (typeName === types.VIDEO_ENDED) {
+    playAfterEnded();
+  }
 });
 </script>
 
@@ -227,13 +419,19 @@ ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
   width: 100%;
   max-width: 480px;
   margin: 0 auto;
-  padding: 24px 0 0 0;
+  padding: 10px 0 0 0;
 }
 
-.alist-actions {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
+.video-error {
+  margin: 0 8px 8px;
+
+  :deep(.el-alert__title) {
+    display: block;
+    max-width: 236px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .empty-queue {
@@ -241,7 +439,7 @@ ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  height: 120px;
+  height: 92px;
   .empty-icon {
     font-size: 24px;
     color: #b0b0b0;
@@ -256,7 +454,7 @@ ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
 .queue-tree {
   border: 1px solid rgba(255, 255, 255, 0.16);
   margin: 8px 8px 0;
-  height: 120px;
+  height: 104px;
   overflow-y: scroll;
   border-radius: 8px;
 }
@@ -276,11 +474,11 @@ ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
 }
 .video-actions {
   position: relative;
-  border-radius: 16px;
+  border-radius: 8px;
   margin: 0 auto;
 }
 .action-buttons {
-  padding: 8px;
+  padding: 6px 8px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -298,18 +496,56 @@ ipc.on(types.VIDEO_TIMEUPDATE, (...args: unknown[]) => {
   padding: 0 4px;
   position: absolute;
   right: 24px;
-  top: 10px;
+  top: 8px;
   min-width: 60px;
   font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+.playback-tools {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 8px 4px;
+}
+.tool-button {
+  width: 32px;
+  min-width: 32px;
+
+  &.active {
+    background-color: var(--el-color-primary);
+    color: #ffffff;
+  }
+}
+.speed-select {
+  width: 82px;
+}
+.volume-panel {
+  width: 100%;
+}
+.volume-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--el-text-color-primary);
+  font-size: 13px;
+}
+.mute-toggle {
+  min-height: 28px;
 }
 .list-actions {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin: 8px 8px 0;
-
-  .clear-btn {
-    font-weight: 500;
-    color: #ff4d4f;
-  }
+}
+.add-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.clear-btn {
+  font-weight: 500;
+  color: #ff4d4f;
 }
 </style>

--- a/src/Player/VideoPlayer.vue
+++ b/src/Player/VideoPlayer.vue
@@ -68,10 +68,10 @@ function getVideoErrorMessage(): string {
   if (!error) return `Failed to play ${fileName}.`;
 
   const reasons: Record<number, string> = {
-    [MediaError.MEDIA_ERR_ABORTED]: "Playback was aborted.",
-    [MediaError.MEDIA_ERR_NETWORK]: "A network error occurred while loading the media.",
-    [MediaError.MEDIA_ERR_DECODE]: "The media could not be decoded.",
-    [MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED]: "The media format or path is not supported.",
+    1: "Playback was aborted.",
+    2: "A network error occurred while loading the media.",
+    3: "The media could not be decoded.",
+    4: "The media format or path is not supported.",
   };
 
   return `${fileName}: ${reasons[error.code] ?? "The media could not be played."}`;

--- a/src/Player/VideoPlayer.vue
+++ b/src/Player/VideoPlayer.vue
@@ -10,6 +10,7 @@
     @pause="onVideoPause"
     @ended="onVideoEnded"
     @loadstart="onVideoLoadStart"
+    @error="onVideoError"
   ></video>
 </template>
 
@@ -22,6 +23,7 @@ import * as types from "@/mutation-types";
 const playerStore = usePlayerStore();
 const video = ref<HTMLVideoElement | null>(null);
 const videoEl = ref<HTMLVideoElement | null>(null);
+const pendingStartTime = ref<number>(0);
 
 const currentFile = computed(() => playerStore.currentFile);
 const videoSource = computed(() => {
@@ -41,9 +43,44 @@ const videoSource = computed(() => {
 
 // 変数削除
 
+function applyPlaybackPreferences() {
+  if (!videoEl.value) return;
+
+  videoEl.value.volume = playerStore.volume;
+  videoEl.value.muted = playerStore.muted;
+  videoEl.value.playbackRate = playerStore.playbackRate;
+}
+
+function seekToPendingStartTime() {
+  if (!videoEl.value) return;
+  if (pendingStartTime.value <= 0) return;
+  if (!Number.isFinite(videoEl.value.duration)) return;
+  if (pendingStartTime.value >= videoEl.value.duration - 2) return;
+
+  videoEl.value.currentTime = pendingStartTime.value;
+  pendingStartTime.value = 0;
+}
+
+function getVideoErrorMessage(): string {
+  const error = videoEl.value?.error;
+  const fileName = currentFile.value?.name ?? "video";
+
+  if (!error) return `Failed to play ${fileName}.`;
+
+  const reasons: Record<number, string> = {
+    [MediaError.MEDIA_ERR_ABORTED]: "Playback was aborted.",
+    [MediaError.MEDIA_ERR_NETWORK]: "A network error occurred while loading the media.",
+    [MediaError.MEDIA_ERR_DECODE]: "The media could not be decoded.",
+    [MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED]: "The media format or path is not supported.",
+  };
+
+  return `${fileName}: ${reasons[error.code] ?? "The media could not be played."}`;
+}
+
 // コンポーネントがマウントされたときにビデオ要素への参照を設定
 onMounted(() => {
   videoEl.value = video.value;
+  applyPlaybackPreferences();
 
   // メインプロセスからのPLAY_FILEメッセージをリッスン
   ipc.on(types.CONNECT_COMMIT, (...args: unknown[]) => {
@@ -53,6 +90,8 @@ onMounted(() => {
         const data = JSON.parse(payload);
         if (data.file && data.file.path) {
           console.log("[VideoPlayer] Received file from main process:", data.file);
+
+          pendingStartTime.value = typeof data.startTime === "number" ? data.startTime : 0;
 
           // ストアを更新して再生を開始
           playerStore.openFile(data.file);
@@ -83,6 +122,24 @@ onMounted(() => {
       if (videoEl.value) {
         videoEl.value.play();
       }
+    }
+
+    if (typeName === types.VIDEO_VOLUME) {
+      const data = JSON.parse(payload);
+      playerStore.setVolume(data.volume);
+      applyPlaybackPreferences();
+    }
+
+    if (typeName === types.VIDEO_MUTED) {
+      const data = JSON.parse(payload);
+      playerStore.setMuted(data.muted);
+      applyPlaybackPreferences();
+    }
+
+    if (typeName === types.VIDEO_PLAYBACK_RATE) {
+      const data = JSON.parse(payload);
+      playerStore.setPlaybackRate(data.playbackRate);
+      applyPlaybackPreferences();
     }
   });
 });
@@ -120,8 +177,15 @@ watch(
   },
 );
 
+watch(
+  () => [playerStore.volume, playerStore.muted, playerStore.playbackRate],
+  () => applyPlaybackPreferences(),
+);
+
 function onVideoCanplay() {
   if (videoEl.value) {
+    applyPlaybackPreferences();
+    seekToPendingStartTime();
     playerStore.onVideoCanplay(videoEl.value.duration);
   }
 }
@@ -137,7 +201,7 @@ function onVideoPlay() {
 }
 
 function onVideoPause() {
-  playerStore.onVideoPause();
+  playerStore.onVideoPause(videoEl.value?.currentTime);
 }
 
 function onVideoEnded() {
@@ -145,7 +209,11 @@ function onVideoEnded() {
 }
 
 function onVideoLoadStart() {
-  playerStore.onVideoPause();
+  playerStore.pauseVideo();
+}
+
+function onVideoError() {
+  playerStore.onVideoError(getVideoErrorMessage());
 }
 </script>
 

--- a/src/mutation-types.ts
+++ b/src/mutation-types.ts
@@ -14,9 +14,13 @@ export const SORT_QUEUE = "SORT_QUEUE";
 export const VIDEO_TIMEUPDATE = "VIDEO_TIMEUPDATE";
 export const VIDEO_CANPLAY = "VIDEO_CANPLAY";
 export const VIDEO_SEEK = "VIDEO_SEEK";
+export const VIDEO_VOLUME = "VIDEO_VOLUME";
+export const VIDEO_MUTED = "VIDEO_MUTED";
+export const VIDEO_PLAYBACK_RATE = "VIDEO_PLAYBACK_RATE";
 export const VIDEO_PLAYED = "VIDEO_PLAYED";
 export const VIDEO_PAUSED = "VIDEO_PAUSED";
 export const VIDEO_ENDED = "VIDEO_ENDED";
+export const VIDEO_ERROR = "VIDEO_ERROR";
 
 export const CHANGE_MODE = "CHANGE_MODE";
 export const CHANGE_OPACITY = "CHANGE_OPACITY";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,8 +29,9 @@ const controllerCommitMap: Record<string, (payload: any) => void> = {
   [types.VIDEO_TIMEUPDATE]: (payload) => videoStore.videoTimeupdate(payload),
   [types.VIDEO_SEEK]: (payload) => videoStore.videoSeek(payload),
   [types.VIDEO_PLAYED]: () => videoStore.videoPlayed(),
-  [types.VIDEO_PAUSED]: () => videoStore.videoPaused(),
+  [types.VIDEO_PAUSED]: (payload) => videoStore.videoPaused(payload),
   [types.VIDEO_ENDED]: () => videoStore.videoEnded(),
+  [types.VIDEO_ERROR]: (payload) => videoStore.setVideoError(payload),
   [types.RELOAD]: () => settingsStore.reload(),
   [types.RESET]: () => settingsStore.reset(),
   [types.RESIZED_PLAYER]: () => settingsStore.resizePlayer({ mode: false }),
@@ -46,6 +47,9 @@ const playerCommitMap: Record<string, (payload: any) => void> = {
   [types.SET_CLICKTHROUGH]: (payload) => playerStore.setClickthrough(payload.clickThrough),
   [types.RESIZE_PLAYER]: (payload) => playerStore.setResizeMode(payload.mode),
   [types.VIDEO_SEEK]: (payload) => playerStore.seekVideo(payload.percentage),
+  [types.VIDEO_VOLUME]: (payload) => playerStore.setVolume(payload.volume),
+  [types.VIDEO_MUTED]: (payload) => playerStore.setMuted(payload.muted),
+  [types.VIDEO_PLAYBACK_RATE]: (payload) => playerStore.setPlaybackRate(payload.playbackRate),
   [types.PAUSE_FILE]: () => playerStore.pauseVideo(),
   [types.RESUME_FILE]: () => playerStore.resumeVideo(),
   [types.OPEN_URL]: (payload) => playerStore.openUrl(payload.src),
@@ -57,7 +61,7 @@ const playerCommitMap: Record<string, (payload: any) => void> = {
 };
 
 // 現在のウィンドウがPlayerかControllerかを判定
-const isPlayerWindow = window.location.pathname.includes("/player");
+const isPlayerWindow = window.location.pathname.includes("/player") || window.location.hash.startsWith("#/player");
 const commitMap = isPlayerWindow ? playerCommitMap : controllerCommitMap;
 
 ipc.on(types.CONNECT_COMMIT, (...args: unknown[]) => {

--- a/src/store/modules/player.ts
+++ b/src/store/modules/player.ts
@@ -20,6 +20,9 @@ export const usePlayerStore = defineStore("player", () => {
   const isPlaying = ref<boolean>(false);
   const duration = ref<number>(0);
   const currentTime = ref<number>(0);
+  const volume = ref<number>(1);
+  const muted = ref<boolean>(false);
+  const playbackRate = ref<number>(1);
 
   // Web
   const currentUrl = ref<string>("");
@@ -72,14 +75,31 @@ export const usePlayerStore = defineStore("player", () => {
     ipc.commit(types.VIDEO_PLAYED);
   }
 
-  function onVideoPause() {
+  function setVolume(newVolume: number) {
+    volume.value = Math.min(1, Math.max(0, newVolume));
+  }
+
+  function setMuted(isMuted: boolean) {
+    muted.value = isMuted;
+  }
+
+  function setPlaybackRate(rate: number) {
+    playbackRate.value = rate;
+  }
+
+  function onVideoPause(time?: number) {
     isPlaying.value = false;
-    ipc.commit(types.VIDEO_PAUSED);
+    ipc.commit(types.VIDEO_PAUSED, typeof time === "number" ? { currentTime: time } : {});
   }
 
   function onVideoEnded() {
     isPlaying.value = false;
     ipc.commit(types.VIDEO_ENDED);
+  }
+
+  function onVideoError(message: string) {
+    isPlaying.value = false;
+    ipc.commit(types.VIDEO_ERROR, { message });
   }
 
   function seekVideo(percentage: number) {
@@ -113,6 +133,9 @@ export const usePlayerStore = defineStore("player", () => {
     isPlaying,
     duration,
     currentTime,
+    volume,
+    muted,
+    playbackRate,
     currentUrl,
 
     // 計算プロパティ
@@ -129,6 +152,9 @@ export const usePlayerStore = defineStore("player", () => {
     pauseVideo,
     resumeVideo,
     openUrl,
+    setVolume,
+    setMuted,
+    setPlaybackRate,
 
     // IPCへのアクション
     onVideoCanplay,
@@ -136,5 +162,6 @@ export const usePlayerStore = defineStore("player", () => {
     onVideoPlay,
     onVideoPause,
     onVideoEnded,
+    onVideoError,
   };
 });

--- a/src/store/modules/video.ts
+++ b/src/store/modules/video.ts
@@ -83,6 +83,7 @@ export const useVideoStore = defineStore("video", () => {
   function selectVideo(payload: { index: number }) {
     playPointer.value = payload.index;
     currentFile.value = queues.value[payload.index] ?? null;
+    lastPositionSaveSecond.value = 0;
     video.error = "";
   }
 
@@ -161,6 +162,7 @@ export const useVideoStore = defineStore("video", () => {
         name: payload.file.name,
         path: payload.file.path,
       };
+      lastPositionSaveSecond.value = 0;
       video.error = "";
 
       // ファイルが設定されたら、自動的に再生スイッチをオンにする

--- a/src/store/modules/video.ts
+++ b/src/store/modules/video.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { useStorage } from "@vueuse/core";
-import { ref, reactive } from "vue";
+import { ref, reactive, computed } from "vue";
 
 // キューアイテムの型定義
 interface QueueItem {
@@ -8,18 +8,45 @@ interface QueueItem {
   path: string; // 絶対パス
 }
 
+type PlaybackMode = "sequence" | "repeat-all" | "repeat-one" | "shuffle";
+
+const MAX_RECENT_FILES = 12;
+const POSITION_SAVE_INTERVAL_SECONDS = 5;
+
+/**
+ * Builds a deduplicated recent-files list with newest entries first.
+ */
+function mergeRecentFiles(currentFiles: Array<QueueItem>, files: Array<QueueItem>): Array<QueueItem> {
+  const uniqueFiles = [...files, ...currentFiles].reduce<Array<QueueItem>>((items, file) => {
+    if (!file.path || items.some((item) => item.path === file.path)) return items;
+    return [...items, file];
+  }, []);
+
+  return uniqueFiles.slice(0, MAX_RECENT_FILES);
+}
+
 export const useVideoStore = defineStore("video", () => {
   // キューアイテムの配列として保存
   const queues = useStorage<Array<QueueItem>>("queues", []);
+  const recentFiles = useStorage<Array<QueueItem>>("recentFiles", []);
+  const playbackPositions = useStorage<Record<string, number>>("playbackPositions", {});
+  const playbackMode = useStorage<PlaybackMode>("playbackMode", "sequence");
+  const volume = useStorage<number>("videoVolume", 1);
+  const muted = useStorage<boolean>("videoMuted", false);
+  const playbackRate = useStorage<number>("videoPlaybackRate", 1);
   const playPointer = ref<number | null>(null);
   const currentFile = ref<QueueItem | null>(null);
+  const lastPositionSaveSecond = ref<number>(0);
   const video = reactive({
     duration: 0,
     currentTime: 0,
     seekPercentage: 0,
     isPlaying: false,
     switch: false, // switch play/pause control by controller
+    error: "",
   });
+
+  const hasRecentFiles = computed(() => recentFiles.value.length > 0);
 
   function dropFile(payload: { file: QueueItem | { name: string; path: string } }) {
     // 完全なQueueItemを作成して追加
@@ -30,6 +57,17 @@ export const useVideoStore = defineStore("video", () => {
 
     console.log("Adding file to queue:", queueItem);
     queues.value.push(queueItem);
+    addRecentFiles([queueItem]);
+  }
+
+  function addQueues(files: Array<QueueItem | { name: string; path: string }>) {
+    const queueItems = files.map((file) => ({
+      name: file.name,
+      path: file.path,
+    }));
+
+    queues.value.push(...queueItems);
+    addRecentFiles(queueItems);
   }
 
   function pauseFile() {
@@ -45,14 +83,23 @@ export const useVideoStore = defineStore("video", () => {
   function selectVideo(payload: { index: number }) {
     playPointer.value = payload.index;
     currentFile.value = queues.value[payload.index] ?? null;
+    video.error = "";
   }
 
   function removeQueue(payload: { index: number }) {
     queues.value.splice(payload.index, 1);
+    if (playPointer.value === payload.index) {
+      playPointer.value = null;
+      currentFile.value = null;
+    } else if (playPointer.value !== null && playPointer.value > payload.index) {
+      playPointer.value -= 1;
+    }
   }
 
   function clearQueues() {
     queues.value = [];
+    playPointer.value = null;
+    currentFile.value = null;
   }
 
   function sortQueue(payload: { oldIndex: number; newIndex: number }) {
@@ -64,6 +111,7 @@ export const useVideoStore = defineStore("video", () => {
   function videoCanplay(payload: { duration: number }) {
     video.duration = payload.duration;
     video.switch = true;
+    video.error = "";
     // 再生可能になったら自動的に再生を開始する
     setTimeout(() => {
       video.switch = true;
@@ -72,6 +120,7 @@ export const useVideoStore = defineStore("video", () => {
 
   function videoTimeupdate(payload: { currentTime: number }) {
     video.currentTime = payload.currentTime;
+    saveCurrentPlaybackPosition(payload.currentTime);
   }
 
   function videoSeek(payload: { percentage: number }) {
@@ -83,16 +132,18 @@ export const useVideoStore = defineStore("video", () => {
     video.switch = true;
   }
 
-  function videoPaused() {
+  function videoPaused(payload?: { currentTime?: number }) {
     video.isPlaying = false;
     video.switch = false;
+    if (typeof payload?.currentTime === "number") {
+      saveCurrentPlaybackPosition(payload.currentTime, true);
+    }
   }
 
   function videoEnded() {
-    if (queues.value[(playPointer.value ?? -1) + 1]) {
-      playPointer.value = (playPointer.value ?? -1) + 1;
-      currentFile.value = queues.value[playPointer.value] ?? null;
-    }
+    video.isPlaying = false;
+    video.switch = false;
+    if (currentFile.value) clearPlaybackPosition(currentFile.value.path);
   }
 
   function addQueue(file: QueueItem | { name: string; path: string }) {
@@ -110,6 +161,7 @@ export const useVideoStore = defineStore("video", () => {
         name: payload.file.name,
         path: payload.file.path,
       };
+      video.error = "";
 
       // ファイルが設定されたら、自動的に再生スイッチをオンにする
       setTimeout(() => {
@@ -120,12 +172,80 @@ export const useVideoStore = defineStore("video", () => {
     }
   }
 
+  function setPlaybackMode(mode: PlaybackMode) {
+    playbackMode.value = mode;
+  }
+
+  function setVolume(newVolume: number) {
+    volume.value = Math.min(1, Math.max(0, newVolume));
+    if (volume.value > 0 && muted.value) muted.value = false;
+  }
+
+  function setMuted(isMuted: boolean) {
+    muted.value = isMuted;
+  }
+
+  function setPlaybackRate(rate: number) {
+    playbackRate.value = rate;
+  }
+
+  function addRecentFiles(files: Array<QueueItem>) {
+    recentFiles.value = mergeRecentFiles(recentFiles.value, files);
+  }
+
+  function clearRecentFiles() {
+    recentFiles.value = [];
+  }
+
+  function getPlaybackPosition(filePath: string): number {
+    return playbackPositions.value[filePath] ?? 0;
+  }
+
+  function saveCurrentPlaybackPosition(currentTime: number, force = false) {
+    if (!currentFile.value) return;
+    if (!Number.isFinite(currentTime)) return;
+    if (currentTime < 1) return;
+
+    const wholeSecond = Math.floor(currentTime);
+    if (!force && wholeSecond - lastPositionSaveSecond.value < POSITION_SAVE_INTERVAL_SECONDS) return;
+
+    lastPositionSaveSecond.value = wholeSecond;
+    playbackPositions.value = {
+      ...playbackPositions.value,
+      [currentFile.value.path]: wholeSecond,
+    };
+  }
+
+  function clearPlaybackPosition(filePath: string) {
+    const nextPositions = { ...playbackPositions.value };
+    delete nextPositions[filePath];
+    playbackPositions.value = nextPositions;
+  }
+
+  function setVideoError(payload: { message: string }) {
+    video.error = payload.message;
+    video.isPlaying = false;
+    video.switch = false;
+  }
+
+  function clearVideoError() {
+    video.error = "";
+  }
+
   return {
     queues,
+    recentFiles,
+    hasRecentFiles,
+    playbackPositions,
+    playbackMode,
+    volume,
+    muted,
+    playbackRate,
     playPointer,
     currentFile,
     video,
     dropFile,
+    addQueues,
     addQueue,
     pauseFile,
     resumeFile,
@@ -140,5 +260,15 @@ export const useVideoStore = defineStore("video", () => {
     videoPaused,
     videoEnded,
     setCurrentFile,
+    setPlaybackMode,
+    setVolume,
+    setMuted,
+    setPlaybackRate,
+    addRecentFiles,
+    clearRecentFiles,
+    getPlaybackPosition,
+    clearPlaybackPosition,
+    setVideoError,
+    clearVideoError,
   };
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,7 @@ export interface ElectronAPI {
   readClipboardText(): string;
   getFilePath: (file: File) => string;
   pathToFileURL: (filePath: string) => string;
+  showOpenDialog(options: unknown): Promise<unknown>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Harden Electron remote web content boundaries by removing privileged preload from WebContentsView, validating IPC senders, adding custom app protocol/CSP, and tokenizing media:// file access.
- Add video playback features: real previous/next playback, autoplay next, repeat all, repeat one, shuffle, volume, mute, playback speed, resume positions, folder import, recent files, and inline playback errors.
- Keep the compact dark controller style while extending controls with small buttons, popovers, and a speed selector.

## Validation
- pnpm run lint: passed
- Electron main tsc check: passed
- git diff --check: passed
- pnpm run test: fails because package.json calls missing script test:e2e (pre-existing)
